### PR TITLE
Surface Memberful export markup change instead of cryptic IndexError

### DIFF
--- a/src/jg/coop/lib/memberful.py
+++ b/src/jg/coop/lib/memberful.py
@@ -234,8 +234,19 @@ def memberful_url(account_id: int | str) -> str:
 
 
 def parse_export_id(html_tree: html.HtmlElement) -> int:
-    html_element = html_tree.cssselect("*[data-auto-refreshable-url-value]")[0]
-    refreshable_url = html_element.get("data-auto-refreshable-url-value")
+    html_elements = html_tree.cssselect("*[data-auto-refreshable-url-value]")
+    if not html_elements:
+        # Memberful occasionally changes the markup of the export response. When
+        # that happens the selector stops matching and we used to fail with a
+        # cryptic "list index out of range". Surface the actual HTML instead so
+        # the new structure can be inspected (it ends up in the Discord report).
+        snippet = html.tostring(html_tree, encoding="unicode").strip()[:1500]
+        raise DownloadError(
+            "Could not find the export element carrying "
+            "'data-auto-refreshable-url-value'. Memberful likely changed its "
+            f"export response markup. HTML received:\n{snippet}"
+        )
+    refreshable_url = html_elements[0].get("data-auto-refreshable-url-value")
 
     # refreshable_url is something like /admin/members/exports/68746
     return int(refreshable_url.split("/")[-1])

--- a/tests/test_lib_memberful.py
+++ b/tests/test_lib_memberful.py
@@ -1,7 +1,12 @@
 import pytest
 from lxml import html
 
-from jg.coop.lib.memberful import from_cents, parse_export_id, parse_tier_name
+from jg.coop.lib.memberful import (
+    DownloadError,
+    from_cents,
+    parse_export_id,
+    parse_tier_name,
+)
 
 
 def test_parse_export_id_members():
@@ -65,6 +70,15 @@ def test_parse_export_id_cancellations():
     )
 
     assert parse_export_id(html_tree) == 68751
+
+
+def test_parse_export_id_missing_element_raises_download_error():
+    html_tree = html.fromstring(
+        "<turbo-frame id='modal'><p>Something Memberful changed</p></turbo-frame>"
+    )
+
+    with pytest.raises(DownloadError, match="Something Memberful changed"):
+        parse_export_id(html_tree)
 
 
 def test_from_cents():


### PR DESCRIPTION
## What's happening

The daily `subscriptions_csv` sync posts `Failed to fetch CSV data from Memberful: list index out of range` to the `#byznys` Discord channel every morning (started ~26 June 2026). The CircleCI build itself stays **green** — the exception is caught in `main()` and only reported to Discord, so it's easy to miss.

## Root cause

Pulled the full traceback from the CircleCI `sync-1` job (build 73610, node 18):

```
File "src/jg/coop/sync/subscriptions_csv/__init__.py", line 68, in main
    for csv_row in memberful.download_csv(path="/admin/members/exports", ...)
File "src/jg/coop/lib/memberful.py", line 208, in _download_csv
    export_id = parse_export_id(html_tree)
File "src/jg/coop/lib/memberful.py", line 237, in parse_export_id
    html_element = html_tree.cssselect("*[data-auto-refreshable-url-value]")[0]
IndexError: list index out of range
```

So:

- The GraphQL API part works fine (fetches all ~3145 members).
- Auth works.
- The **members CSV export** — `POST /admin/members/exports` — now returns a response with **no `Location` header** *and* HTML that **no longer contains the `data-auto-refreshable-url-value` element**. `parse_export_id` does `cssselect(...)[0]` on an empty list → `IndexError`.

Memberful evidently changed the markup/flow of the members export response. The cancellations export (`/admin/csv_exports`) is never reached because the members export fails first.

## What this PR does

I don't have Memberful credentials to reproduce locally and see the new markup, so this **doesn't fix the export itself yet**. It converts the unactionable `IndexError` into a `DownloadError` that includes the actual HTML Memberful returned. That HTML reaches the Discord error report (and CI logs), which is exactly the data needed to write the real parser fix.

- `parse_export_id` now raises `DownloadError` with a 1500-char HTML snippet when the selector matches nothing.
- Added a test for the new error path.

## Follow-up needed to fully fix

Once this lands and the next sync runs (or someone runs the export manually while logged into Memberful admin), the Discord message / CI log will show the new response markup. With that we can decide whether to:

- update the selector / parsing, or
- switch to the `Location`-header / redirect path if Memberful now redirects to the export, or
- derive the export id from `response.url` / `response.history`.

Happy to follow up with the parser fix once we can see the new HTML.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TYcsVxsPNrkLZbNgq8va13)_