### PR TITLE
Exclude it-academy.sk from link checking (flaky server, not gone)

### DIFF
--- a/lychee.toml
+++ b/lychee.toml
@@ -56,6 +56,11 @@ exclude = [
   # Webcal
   "^webcal://",
 
+  # Flaky/overloaded server – returns intermittent 500s, TLS errors, and
+  # timeouts while the site is in fact live (course pages load with current
+  # course dates and the company is active in the Slovak business registry)
+  "^https://(www\\.)?it-academy\\.sk",
+
   # Anti-scraping protections
   "^https://(www\\.)?(linkedin|facebook|reddit)\\.com",
   "^https://(www\\.)?(beeit|glancemedia|prace\\.rovnou|keyguru)\\.cz",


### PR DESCRIPTION
## What

Adds `^https://(www\.)?it-academy\.sk` to the `exclude` list in `lychee.toml`.

## Why

The link check has been failing on **it-academy.sk** for a few weeks (intermittent 500s / TLS errors / timeouts). I investigated whether the provider is gone or just having server trouble:

- **Site is live.** Crawling multiple pages: the homepage and `/terminy/` intermittently time out / fail TLS, but course pages return HTTP 200 with full content — e.g. `/kurz/confluence/` (~52 KB) and `/kurz/it-management/` (~61 KB) both list **2026 course terms, prices in €, "Objednať" (Order) buttons, and a lecturer**. Wayback also has a successful snapshot from April 2026.
- **Company is active.** IT Academy s.r.o., IČO **46759786**, is **active** in the Slovak business registry — no liquidation (`likvidácia`), no bankruptcy/insolvency (`konkurz`: NIE), no temporary protection. 2024 financial statement filed (profit, ~€204k revenue); last registry update 23.7.2025.

Conclusion: this is a **flaky/overloaded server**, not a dead course provider. So the fix is a link-check exclusion rather than setting the `is_gone` flag on the course provider.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jbvayt4puSk9Ge1Ng56XyY)_