### PR TITLE
Recommend filling in a public email in the GitHub profile handbook

### DIFF
--- a/src/jg/coop/web/docs/handbook/github-profile.md
+++ b/src/jg/coop/web/docs/handbook/github-profile.md
@@ -147,6 +147,8 @@ Velké množství juniorů na vlastní obrázek kašle, takže i když je to dvo
 Doplň si v [nastavení](https://github.com/settings/profile) svoje jméno.
 Pokud chceš, uveď _Bio_, tzn. nějakou větu o sobě.
 
+Vyplatí se nastavit i _Public email_ — přes e-mail se ti zaměstnavatelé ozývají nejspolehlivěji, výrazně častěji než přes LinkedIn.
+
 Můžeš vyplnit _Location_, ale není to nutné a klidně napiš jen „Czechia“, stačí to.
 GitHub je globální, takže jestli tam chceš dát město, doplň i stát, třeba „Prešov, Slovakia“.
 


### PR DESCRIPTION
## Why

Companion to juniorguru/hen#145 (which adds a `hen` rule warning about a missing public email). That rule links to the handbook's *Vyplň si základní údaje* section — but the section didn't mention email at all, so readers had no explanation of the reasoning.

## What

Adds one sentence to `src/jg/coop/web/docs/handbook/github-profile.md`, in the *Vyplň si základní údaje* section, recommending the _Public email_ field and explaining why it's worth it:

> Vyplatí se nastavit i _Public email_ — přes e-mail se ti zaměstnavatelé ozývají nejspolehlivěji, výrazně častěji než přes LinkedIn.

Phrased as a recommendation rather than a demand, matching the deliberately non-mandatory `WARNING` severity in the `hen` rule (whether to publish an email is a personal call). Tone and italic field-name style match the surrounding _Bio_ / _Location_ / _Pronouns_ paragraphs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y7xZUTQL5t35upAvGrjGZs

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y7xZUTQL5t35upAvGrjGZs)_