### PR TITLE
Restore green tests after ruff 0.16 default rule expansion

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,7 +88,7 @@ asyncio_default_fixture_loop_scope = "function"
 target-version = "py313"
 
 [tool.ruff.lint]
-extend-select = ["I"]
+select = ["E4", "E7", "E9", "F", "I"]
 
 [tool.ruff.lint.isort]
 combine-as-imports = true


### PR DESCRIPTION
## Problem

The test suite fails with 33 `ruff` failures (pytest runs ruff via `pytest-ruff` as part of `addopts`).

## Root cause

Commit `18b5259` ("update packages 📦") bumped ruff `0.15.22 → 0.16.0`. Ruff 0.16 **expanded its default lint rule set** well beyond the historical `E4/E7/E9/F`. Verified with `ruff check --isolated` (ignores all config) on a trivial file — it now flags rules like `C408` that were never in the old default.

Since `pytest-ruff` runs ruff against the whole codebase, ~692 pre-existing, previously-clean lint patterns (`DTZ`, `C408`, `UP035`, `SIM117`, …) suddenly became test failures.

## Fix

The config only ever opted into isort (`extend-select = ["I"]`) on top of the old default. Replace `extend-select` with an explicit `select` that pins that same intended rule set:

```toml
[tool.ruff.lint]
select = ["E4", "E7", "E9", "F", "I"]
```

Because `select` replaces the built-in default (rather than extending it), the 0.16 default expansion no longer applies, and the selection matches what the project always intended.

## Verification

`uv run pytest` → **1114 passed, 1 skipped** (was 33 failed, 1081 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qx8pQh3qW7jrruNRZ55atW

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qx8pQh3qW7jrruNRZ55atW)_