### PR TITLE
Assert top_members_limit in tests that computed it without asserting

### DIFF
--- a/tests/test_models_club.py
+++ b/tests/test_models_club.py
@@ -288,21 +288,21 @@ def test_user_top_members_limit_is_five_percent(test_db):
     for id_ in range(100):
         create_user(id_)
 
-    ClubUser.top_members_limit() == 5
+    assert ClubUser.top_members_limit() == 5
 
 
 def test_user_top_members_limit_doesnt_count_past_members(test_db):
     for id_ in range(200):
         create_user(id_, is_member=id_ < 100)
 
-    ClubUser.top_members_limit() == 5
+    assert ClubUser.top_members_limit() == 5
 
 
 def test_user_top_members_limit_doesnt_count_bots(test_db):
     for id_ in range(200):
         create_user(id_, is_bot=id_ < 100)
 
-    ClubUser.top_members_limit() == 5
+    assert ClubUser.top_members_limit() == 5
 
 
 def test_user_top_members_limit_rounds_up(test_db):
@@ -310,7 +310,7 @@ def test_user_top_members_limit_rounds_up(test_db):
     create_user(2)
     create_user(3)
 
-    ClubUser.top_members_limit() == 1
+    assert ClubUser.top_members_limit() == 1
 
 
 def test_avatars_listing(test_db):


### PR DESCRIPTION
## Problem

Four tests in `tests/test_models_club.py` evaluate `ClubUser.top_members_limit() == N` as a bare expression and throw the result away. They assert nothing — each would pass even if `top_members_limit()` returned the wrong value:

```python
def test_user_top_members_limit_is_five_percent(test_db):
    for id_ in range(100):
        create_user(id_)

    ClubUser.top_members_limit() == 5   # result discarded — asserts nothing
```

Affected tests:
- `test_user_top_members_limit_is_five_percent`
- `test_user_top_members_limit_doesnt_count_past_members`
- `test_user_top_members_limit_doesnt_count_bots`
- `test_user_top_members_limit_rounds_up`

## Fix

Add the missing `assert` to each. All four assertions hold against the current implementation, so this makes the tests real without changing any production code.

## Verification

`uv run pytest tests/test_models_club.py -k top_members_limit` → **4 passed**.

## Context

Factored out of #1690 as a standalone, mergeable-with-priority fix. This is the one genuinely pre-existing bug in that branch; the rest of #1690 is ruff-0.16 modernization. (The `StopIteration` corrections in #1690 are deliberately excluded here — they only apply once `[...][0]` is rewritten to `next(...)`, which isn't the case on `main`.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qx8pQh3qW7jrruNRZ55atW

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qx8pQh3qW7jrruNRZ55atW)_