### PR TITLE
Use collections.abc types and normalize dict literals; update ruff config

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,7 +88,7 @@ asyncio_default_fixture_loop_scope = "function"
 target-version = "py313"
 
 [tool.ruff.lint]
-select = ["E4", "E7", "E9", "F", "I"]
+select = ["C408", "E4", "E7", "E9", "F", "I", "UP035"]
 
 [tool.ruff.lint.isort]
 combine-as-imports = true

--- a/src/jg/coop/cli/cache.py
+++ b/src/jg/coop/cli/cache.py
@@ -1,7 +1,7 @@
 from collections import Counter
+from collections.abc import Iterable
 from pathlib import Path
 from sqlite3 import OperationalError
-from typing import Iterable
 
 import click
 from diskcache.core import DBNAME

--- a/src/jg/coop/cli/data.py
+++ b/src/jg/coop/cli/data.py
@@ -287,29 +287,29 @@ def merge_diskcaches(table_from: Table, table_to: Table):
             logger_t.debug(f"Row {row_from['key']!r} exists, updating")
             row_to = next(table_to.rows_where("key = ?", [row_from["key"]], limit=1))
             pks = [row_to[pk] for pk in table_to.pks]
-            updates = dict(
-                store_time=skip_none_max(
+            updates = {
+                "store_time": skip_none_max(
                     row_from["store_time"],
                     row_to["store_time"],
                 ),
-                expire_time=skip_none_max(
+                "expire_time": skip_none_max(
                     row_from["expire_time"],
                     row_to["expire_time"],
                 ),
-                access_time=skip_none_max(
+                "access_time": skip_none_max(
                     row_from["access_time"],
                     row_to["access_time"],
                 ),
-                access_count=row_from["access_count"] + row_to["access_count"],
-            )
+                "access_count": row_from["access_count"] + row_to["access_count"],
+            }
             if row_from["store_time"] > row_to["store_time"]:
-                updates |= dict(
-                    tag=row_from["tag"],
-                    size=row_from["size"],
-                    mode=row_from["mode"],
-                    filename=row_from["filename"],
-                    value=row_from["value"],
-                )
+                updates |= {
+                    "tag": row_from["tag"],
+                    "size": row_from["size"],
+                    "mode": row_from["mode"],
+                    "filename": row_from["filename"],
+                    "value": row_from["value"],
+                }
             logger_t.debug(f"Updating {pks!r} with {pformat(updates)}")
             table_to.update(pks, updates)
 

--- a/src/jg/coop/cli/notes.py
+++ b/src/jg/coop/cli/notes.py
@@ -1,8 +1,8 @@
 import asyncio
 import re
 from collections import defaultdict
+from collections.abc import Iterable
 from pathlib import Path
-from typing import Iterable
 
 import click
 import discord

--- a/src/jg/coop/cli/sync.py
+++ b/src/jg/coop/cli/sync.py
@@ -158,7 +158,7 @@ def main(
     images.init_templates_cache()
     with db.connection_context():
         sync = Sync.start(id)
-    context.obj = dict(sync=sync, skip_dependencies=not deps)
+    context.obj = {"sync": sync, "skip_dependencies": not deps}
     logger.debug(
         f"Sync #{id} starts with {sync.count_commands()} commands already recorded"
     )

--- a/src/jg/coop/cli/tidy.py
+++ b/src/jg/coop/cli/tidy.py
@@ -4,10 +4,10 @@ import mimetypes
 import os
 import re
 import subprocess
+from collections.abc import Iterable
 from glob import glob
 from io import BytesIO
 from pathlib import Path
-from typing import Iterable
 
 import click
 from PIL import Image

--- a/src/jg/coop/lib/async_utils.py
+++ b/src/jg/coop/lib/async_utils.py
@@ -1,6 +1,6 @@
 import asyncio
+from collections.abc import Awaitable, Callable
 from functools import partial, wraps
-from typing import Awaitable, Callable
 
 
 semaphores = {}

--- a/src/jg/coop/lib/buttondown.py
+++ b/src/jg/coop/lib/buttondown.py
@@ -1,8 +1,9 @@
 import logging
 import os
+from collections.abc import AsyncGenerator
 from datetime import date
 from enum import StrEnum
-from typing import AsyncGenerator, Self, TypeVar
+from typing import Self, TypeVar
 
 import httpx
 from tenacity import (

--- a/src/jg/coop/lib/cache.py
+++ b/src/jg/coop/lib/cache.py
@@ -1,8 +1,9 @@
 import asyncio
 import logging
+from collections.abc import Callable
 from datetime import timedelta
 from functools import lru_cache, wraps
-from typing import Any, Callable
+from typing import Any
 
 from diskcache import Cache
 from diskcache.core import ENOVAL, args_to_key, full_name

--- a/src/jg/coop/lib/charts.py
+++ b/src/jg/coop/lib/charts.py
@@ -1,10 +1,11 @@
 import calendar
 import itertools
 from collections import defaultdict
+from collections.abc import Callable, Generator, Iterable
 from datetime import date, timedelta
 from functools import cache
 from numbers import Number
-from typing import Callable, Generator, Iterable, TypeVar
+from typing import TypeVar
 
 from slugify import slugify
 

--- a/src/jg/coop/lib/cli.py
+++ b/src/jg/coop/lib/cli.py
@@ -1,10 +1,10 @@
 import asyncio
 import pkgutil
 import threading
+from collections.abc import Awaitable, Callable, Generator
 from functools import wraps
 from importlib import import_module
 from types import ModuleType
-from typing import Awaitable, Callable, Generator
 
 import click
 

--- a/src/jg/coop/lib/discord_club.py
+++ b/src/jg/coop/lib/discord_club.py
@@ -1,11 +1,12 @@
 import asyncio
 import itertools
 import re
+from collections.abc import AsyncGenerator
 from datetime import date, datetime, timedelta, timezone
 from enum import IntEnum, StrEnum, unique
 from functools import wraps
 from pprint import pformat
-from typing import TYPE_CHECKING, AsyncGenerator, TypedDict
+from typing import TYPE_CHECKING, TypedDict
 
 import discord
 import emoji

--- a/src/jg/coop/lib/discord_task.py
+++ b/src/jg/coop/lib/discord_task.py
@@ -2,8 +2,8 @@ import asyncio
 import os
 import sys
 import threading
+from collections.abc import Awaitable, Callable
 from queue import Queue
-from typing import Awaitable, Callable
 
 from jg.coop.lib import loggers
 from jg.coop.lib.discord_club import ClubClient

--- a/src/jg/coop/lib/fakturoid.py
+++ b/src/jg/coop/lib/fakturoid.py
@@ -31,7 +31,7 @@ def auth(
             "User-Agent": user_agent,
             "Authorization": f"Basic {credentials_base64}",
         },
-        json=dict(grant_type="client_credentials"),
+        json={"grant_type": "client_credentials"},
         follow_redirects=True,
     )
     response.raise_for_status()

--- a/src/jg/coop/lib/google_coerce.py
+++ b/src/jg/coop/lib/google_coerce.py
@@ -31,9 +31,14 @@ def parse_int(value):
 
 def parse_boolean_words(value):
     if value is not None:
-        return dict(yes=True, no=False, ano=True, ne=False, true=True, false=False).get(
-            value.strip().lower()
-        )
+        return {
+            "yes": True,
+            "no": False,
+            "ano": True,
+            "ne": False,
+            "true": True,
+            "false": False,
+        }.get(value.strip().lower())
 
 
 def parse_datetime(value):

--- a/src/jg/coop/lib/images.py
+++ b/src/jg/coop/lib/images.py
@@ -4,12 +4,13 @@ import os
 import pickle
 import shutil
 import time
+from collections.abc import Callable, Generator, Iterable
 from functools import lru_cache
 from hashlib import sha256
 from io import BytesIO
 from pathlib import Path
 from subprocess import run
-from typing import Any, Callable, Generator, Iterable
+from typing import Any
 
 from fontTools.ttLib import TTFont
 from fontTools.ttLib.tables._c_m_a_p import CmapSubtable

--- a/src/jg/coop/lib/llm.py
+++ b/src/jg/coop/lib/llm.py
@@ -65,11 +65,11 @@ async def ask_llm(
 ) -> Schema: ...
 
 
-retry_defaults = dict(
-    reraise=True,
-    before_sleep=before_sleep_log(logger, logging.DEBUG),
-    stop=stop_after_attempt(5),
-)
+retry_defaults = {
+    "reraise": True,
+    "before_sleep": before_sleep_log(logger, logging.DEBUG),
+    "stop": stop_after_attempt(5),
+}
 
 
 @mutates("openai", raises=True)

--- a/src/jg/coop/lib/location.py
+++ b/src/jg/coop/lib/location.py
@@ -1,10 +1,11 @@
 import os
 import random
 import re
+from collections.abc import Generator
 from datetime import timedelta
 from decimal import Decimal
 from enum import StrEnum
-from typing import Generator, Literal
+from typing import Literal
 
 import czech_sort
 import httpx

--- a/src/jg/coop/lib/loggers.py
+++ b/src/jg/coop/lib/loggers.py
@@ -2,8 +2,9 @@ import logging
 import os
 import threading
 import time
+from collections.abc import Callable, Generator, Iterable
 from pathlib import Path
-from typing import Callable, Generator, Iterable, TypeVar, cast
+from typing import TypeVar, cast
 
 import click
 

--- a/src/jg/coop/lib/memberful.py
+++ b/src/jg/coop/lib/memberful.py
@@ -3,9 +3,10 @@ import json
 import logging
 import os
 import re
+from collections.abc import Callable, Generator
 from dataclasses import dataclass
 from datetime import date, datetime, timedelta, timezone
-from typing import Any, Callable, Generator
+from typing import Any
 
 import httpx
 from gql import Client, gql

--- a/src/jg/coop/lib/mkdocs_jinja.py
+++ b/src/jg/coop/lib/mkdocs_jinja.py
@@ -1,5 +1,5 @@
+from collections.abc import Callable
 from pathlib import Path
-from typing import Callable
 
 from jinja2 import Environment as BaseEnvironment, FileSystemLoader
 from mkdocs.config import Config

--- a/src/jg/coop/lib/mutations.py
+++ b/src/jg/coop/lib/mutations.py
@@ -1,7 +1,8 @@
 import inspect
+from collections.abc import Generator, Iterable
 from contextlib import contextmanager
 from functools import partial, wraps
-from typing import Any, Generator, Iterable, Literal
+from typing import Any, Literal
 
 from jg.coop.lib import loggers
 from jg.coop.lib.cache import get_cache

--- a/src/jg/coop/lib/template_filters.py
+++ b/src/jg/coop/lib/template_filters.py
@@ -1,10 +1,11 @@
 import math
 import random
 import re
+from collections.abc import Generator, Iterable
 from datetime import UTC, timedelta
 from numbers import Number
 from operator import itemgetter
-from typing import Generator, Iterable, Literal
+from typing import Literal
 from urllib.parse import unquote, urljoin, urlparse, urlunparse
 from zoneinfo import ZoneInfo
 
@@ -175,14 +176,14 @@ def mapping(mapping: dict, keys: Iterable) -> list:
 def mainnav(nav: Navigation) -> Generator[dict, None, None]:
     for item in list(nav)[:6]:
         first_child = _get_first_child(item)
-        yield dict(title=item.title, url=first_child.url, is_active=item.active)
+        yield {"title": item.title, "url": first_child.url, "is_active": item.active}
 
 
 def subnav(nav: Navigation) -> Generator[dict, None, None]:
     mainnav_item = next(item for item in nav if item.active)
     for item in mainnav_item.children:
         first_child = _get_first_child(item)
-        yield dict(title=item.title, url=first_child.url, is_active=item.active)
+        yield {"title": item.title, "url": first_child.url, "is_active": item.active}
 
 
 def _get_first_child(item: StructureItem) -> StructureItem:
@@ -212,14 +213,15 @@ def toc(page: Page) -> Generator[dict, None, None]:
             item_page = item.children[0]
         else:
             item_page = item
-        yield dict(
-            title=item_page.title,
-            url=item_page.url,
-            is_active=item.active,
-            headings=[
-                dict(title=heading.title, url=heading.url) for heading in item_page.toc
+        yield {
+            "title": item_page.title,
+            "url": item_page.url,
+            "is_active": item.active,
+            "headings": [
+                {"title": heading.title, "url": heading.url}
+                for heading in item_page.toc
             ],
-        )
+        }
 
 
 def parent_page(page: Page) -> StructureItem | None:

--- a/src/jg/coop/models/base.py
+++ b/src/jg/coop/models/base.py
@@ -3,11 +3,10 @@ import hashlib
 import json
 import pickle
 import sqlite3
-from collections.abc import Set
+from collections.abc import Iterable, Set
 from enum import Enum
 from functools import cache, wraps
 from pathlib import Path
-from typing import Iterable
 
 from czech_sort import bytes_key as czech_sort_key
 from peewee import (

--- a/src/jg/coop/models/blog.py
+++ b/src/jg/coop/models/blog.py
@@ -1,4 +1,5 @@
-from typing import Iterable, Self
+from collections.abc import Iterable
+from typing import Self
 
 from peewee import CharField, DateField
 

--- a/src/jg/coop/models/candidate.py
+++ b/src/jg/coop/models/candidate.py
@@ -1,9 +1,10 @@
 import itertools
 import json
+from collections.abc import Iterable
 from datetime import date, timedelta
 from enum import StrEnum, auto
 from operator import attrgetter
-from typing import Iterable, Self
+from typing import Self
 
 from peewee import (
     BooleanField,

--- a/src/jg/coop/models/club.py
+++ b/src/jg/coop/models/club.py
@@ -1,9 +1,10 @@
 import math
+from collections.abc import Iterable
 from datetime import date, datetime, timedelta
 from enum import StrEnum, auto, unique
 from itertools import groupby
 from operator import attrgetter
-from typing import Iterable, Optional, Self, TypeVar
+from typing import Optional, Self, TypeVar
 
 from discord import ChannelType
 from peewee import (

--- a/src/jg/coop/models/course_provider.py
+++ b/src/jg/coop/models/course_provider.py
@@ -1,8 +1,9 @@
 import itertools
+from collections.abc import Iterable
 from enum import StrEnum
 from itertools import groupby
 from operator import attrgetter
-from typing import Iterable, Self
+from typing import Self
 
 import czech_sort
 from peewee import BooleanField, CharField, IntegerField, TextField, fn

--- a/src/jg/coop/models/external_story.py
+++ b/src/jg/coop/models/external_story.py
@@ -23,15 +23,15 @@ class ExternalStory(BaseModel):
         return re.sub(r"^www\.", "", urlparse(url).netloc).lower()
 
     def to_card(self) -> dict:
-        return dict(
-            title=self.title,
-            url=self.url,
-            image_path=self.image_path,
-            image_alt=self.name,
-            subtitle=self.name,
-            date=self.date,
-            external=True,
-        )
+        return {
+            "title": self.title,
+            "url": self.url,
+            "image_path": self.image_path,
+            "image_alt": self.name,
+            "subtitle": self.name,
+            "date": self.date,
+            "external": True,
+        }
 
     @classmethod
     def listing(cls):

--- a/src/jg/coop/models/followers.py
+++ b/src/jg/coop/models/followers.py
@@ -1,6 +1,7 @@
 import json
+from collections.abc import Iterable
 from datetime import date
-from typing import Iterable, Self
+from typing import Self
 
 from peewee import Case, CharField, IntegerField
 from playhouse.shortcuts import model_to_dict

--- a/src/jg/coop/models/job.py
+++ b/src/jg/coop/models/job.py
@@ -2,10 +2,11 @@ import itertools
 import json
 import textwrap
 from collections import Counter
+from collections.abc import Iterable
 from datetime import date, datetime, time, timedelta
 from enum import StrEnum, auto
 from operator import attrgetter
-from typing import Iterable, Self
+from typing import Self
 from urllib.parse import quote_plus
 
 from peewee import (
@@ -467,19 +468,19 @@ class ListedJob(BaseModel):
 
     def to_czechitas_api(self) -> dict[str, str | int | datetime | None]:
         return dict(
-            **dict(
-                title=self.title,
-                company_name=self.company_name,
-                url=self.url,
-                remote=self.remote,
-                first_seen_at=datetime.combine(
+            **{
+                "title": self.title,
+                "company_name": self.company_name,
+                "url": self.url,
+                "remote": self.remote,
+                "first_seen_at": datetime.combine(
                     self.posted_on, time(0, 0)
                 ),  # datetime for backwards compatibility
-                last_seen_at=None,  # not relevant anymore, equals to present moment
-                lang=self.lang,
-                juniority_score=None,  # won't expose publicly anymore
-                source=None,  # use external IDs instead
-            ),
+                "last_seen_at": None,  # not relevant anymore, equals to present moment
+                "lang": self.lang,
+                "juniority_score": None,  # won't expose publicly anymore
+                "source": None,  # use external IDs instead
+            },
             **{
                 f"external_ids_{i}": value
                 for i, value in columns(  # renamed elsewhere, but keeping backwards compatible
@@ -498,9 +499,9 @@ class ListedJob(BaseModel):
                 f"employment_types_{i}": value
                 for i, value in columns(self.employment_types, 10)
             },
-            **dict(
-                description_html=self.description_html,
-            ),
+            **{
+                "description_html": self.description_html,
+            },
         )
 
 

--- a/src/jg/coop/models/meetup.py
+++ b/src/jg/coop/models/meetup.py
@@ -1,4 +1,5 @@
-from typing import Iterable, Self
+from collections.abc import Iterable
+from typing import Self
 
 from peewee import CharField, DateTimeField
 

--- a/src/jg/coop/models/members.py
+++ b/src/jg/coop/models/members.py
@@ -1,7 +1,8 @@
 import itertools
 import json
+from collections.abc import Iterable
 from datetime import date
-from typing import Iterable, Self
+from typing import Self
 
 from peewee import CharField, IntegerField
 from playhouse.shortcuts import model_to_dict

--- a/src/jg/coop/models/newsletter.py
+++ b/src/jg/coop/models/newsletter.py
@@ -1,6 +1,7 @@
 import re
+from collections.abc import Iterable
 from datetime import datetime
-from typing import Iterable, Self
+from typing import Self
 
 from peewee import CharField, DateField, IntegerField
 

--- a/src/jg/coop/models/page.py
+++ b/src/jg/coop/models/page.py
@@ -1,4 +1,5 @@
-from typing import Iterable, Self
+from collections.abc import Iterable
+from typing import Self
 
 from peewee import BooleanField, CharField, DateField, IntegerField, fn
 

--- a/src/jg/coop/models/partner.py
+++ b/src/jg/coop/models/partner.py
@@ -1,4 +1,5 @@
-from typing import Iterable, Literal, Self
+from collections.abc import Iterable
+from typing import Literal, Self
 
 from peewee import BooleanField, CharField, DateField, IntegerField, TextField, fn
 

--- a/src/jg/coop/models/podcast.py
+++ b/src/jg/coop/models/podcast.py
@@ -1,6 +1,7 @@
 import math
+from collections.abc import Iterable
 from datetime import date, datetime, time
-from typing import Iterable, Self
+from typing import Self
 from zoneinfo import ZoneInfo
 
 from peewee import BooleanField, CharField, DateField, IntegerField
@@ -61,14 +62,14 @@ class PodcastEpisode(BaseModel):
         return math.ceil(self.media_duration_s / 60)
 
     def to_card(self) -> dict:
-        return dict(
-            title=self.format_title(number=False, affiliation=False),
-            url=self.page_url,
-            image_path=self.image_path,
-            image_alt=self.format_title(),
-            subtitle=self.guest_affiliation,
-            date=self.publish_on,
-        )
+        return {
+            "title": self.format_title(number=False, affiliation=False),
+            "url": self.page_url,
+            "image_path": self.image_path,
+            "image_alt": self.format_title(),
+            "subtitle": self.guest_affiliation,
+            "date": self.publish_on,
+        }
 
     @classmethod
     def get_by_number(cls, number: int):

--- a/src/jg/coop/models/role.py
+++ b/src/jg/coop/models/role.py
@@ -1,5 +1,6 @@
 from collections import Counter
-from typing import Iterable, Self
+from collections.abc import Iterable
+from typing import Self
 
 from peewee import CharField, IntegerField, TextField
 

--- a/src/jg/coop/models/sponsor.py
+++ b/src/jg/coop/models/sponsor.py
@@ -1,6 +1,7 @@
+from collections.abc import Iterable
 from datetime import date
 from itertools import groupby
-from typing import Iterable, Literal, Self
+from typing import Literal, Self
 
 import czech_sort
 from peewee import (

--- a/src/jg/coop/models/stage.py
+++ b/src/jg/coop/models/stage.py
@@ -1,4 +1,5 @@
-from typing import Iterable, Self
+from collections.abc import Iterable
+from typing import Self
 
 from peewee import CharField, IntegerField
 

--- a/src/jg/coop/models/subscription.py
+++ b/src/jg/coop/models/subscription.py
@@ -1,7 +1,8 @@
 from collections import Counter
+from collections.abc import Iterable
 from datetime import date, timedelta
 from enum import StrEnum, unique
-from typing import Iterable, Self
+from typing import Self
 
 from peewee import (
     Case,

--- a/src/jg/coop/models/tip.py
+++ b/src/jg/coop/models/tip.py
@@ -1,4 +1,5 @@
-from typing import Iterable, Self
+from collections.abc import Iterable
+from typing import Self
 
 from peewee import CharField, IntegerField, TextField
 

--- a/src/jg/coop/models/transaction.py
+++ b/src/jg/coop/models/transaction.py
@@ -1,9 +1,10 @@
 import functools
 import json
 import math
+from collections.abc import Iterable
 from datetime import date
 from enum import StrEnum, unique
-from typing import Iterable, Self
+from typing import Self
 
 from peewee import CharField, DateField, IntegerField
 from playhouse.shortcuts import model_to_dict

--- a/src/jg/coop/sync/candidates_dm_reports.py
+++ b/src/jg/coop/sync/candidates_dm_reports.py
@@ -73,8 +73,8 @@ async def sync_candidates_dms(
 
 
 def create_message(candidate: Candidate, emoji: str) -> dict:
-    return dict(
-        content=(
+    return {
+        "content": (
             f"{emoji} Ahoj! "
             "Tvůj profil na [junior.guru/candidates](https://junior.guru/candidates) "
             f"má **nedostatky**, takže je v seznamu kandidátů upozaděný. "
@@ -87,9 +87,9 @@ def create_message(candidate: Candidate, emoji: str) -> dict:
             "Tlačítkem pod touto zprávou přejdi na soubor, pak tři tečky vpravo nahoře, "
             "v menu najdi _Delete file_ a pak to potvrď zeleným _Commit changes_."
         ),
-        view=ui.View(
+        "view": ui.View(
             ui.Button(label="⚠️ Co mám opravit?", url=candidate.report_url),
             ui.Button(label="❌ Smazat profil", url=candidate.yaml_url),
         ),
-        suppress=True,
-    )
+        "suppress": True,
+    }

--- a/src/jg/coop/sync/charts.py
+++ b/src/jg/coop/sync/charts.py
@@ -1,6 +1,7 @@
+from collections.abc import Callable
 from datetime import date
 from operator import attrgetter
-from typing import Any, Callable, NotRequired, TypedDict
+from typing import Any, NotRequired, TypedDict
 
 from jg.coop.cli.sync import main as cli
 from jg.coop.lib import charts, loggers
@@ -129,118 +130,118 @@ def chart(chart_fn: Callable) -> Callable:
 def profit(today: date) -> IntChartDict:
     months = charts.months(BUSINESS_BEGIN_ON, today)
     data = charts.per_month(Transaction.profit, months)
-    return dict(data=data, months=months)
+    return {"data": data, "months": months}
 
 
 @chart
 def profit_ttm(today: date) -> IntChartDict:
     months = charts.months(BUSINESS_BEGIN_ON, today)
     data = charts.per_month(Transaction.profit_ttm, months)
-    return dict(data=data, months=months)
+    return {"data": data, "months": months}
 
 
 @chart
 def revenue(today: date) -> IntChartDict:
     months = charts.months(BUSINESS_BEGIN_ON, today)
     data = charts.per_month(Transaction.revenue, months)
-    return dict(data=data, months=months)
+    return {"data": data, "months": months}
 
 
 @chart
 def revenue_ttm(today: date) -> IntChartDict:
     months = charts.months(BUSINESS_BEGIN_ON, today)
     data = charts.per_month(Transaction.revenue_ttm, months)
-    return dict(data=data, months=months)
+    return {"data": data, "months": months}
 
 
 @chart
 def revenue_growth(today: date) -> FloatChartDict:
     months = charts.months(today.replace(year=today.year - 3), today)
     data = charts.per_month(Transaction.revenue_growth_ptc, months)
-    return dict(data=data, months=months)
+    return {"data": data, "months": months}
 
 
 @chart
 def revenue_ttm_growth(today: date) -> FloatChartDict:
     months = charts.months(today.replace(year=today.year - 3), today)
     data = charts.per_month(Transaction.revenue_ttm_growth_ptc, months)
-    return dict(data=data, months=months)
+    return {"data": data, "months": months}
 
 
 @chart
 def revenue_breakdown(today: date) -> IntBreakdownChartDict:
     months = charts.months(BUSINESS_BEGIN_ON, today)
     data = charts.per_month_breakdown(Transaction.revenue_breakdown, months)
-    return dict(data=data, months=months)
+    return {"data": data, "months": months}
 
 
 @chart
 def cost(today: date) -> IntChartDict:
     months = charts.months(BUSINESS_BEGIN_ON, today)
     data = charts.per_month(Transaction.cost, months)
-    return dict(data=data, months=months)
+    return {"data": data, "months": months}
 
 
 @chart
 def cost_ttm(today: date) -> IntChartDict:
     months = charts.months(BUSINESS_BEGIN_ON, today)
     data = charts.per_month(Transaction.cost_ttm, months)
-    return dict(data=data, months=months)
+    return {"data": data, "months": months}
 
 
 @chart
 def cost_breakdown(today: date) -> IntBreakdownChartDict:
     months = charts.months(BUSINESS_BEGIN_ON, today)
     data = charts.per_month_breakdown(Transaction.cost_breakdown, months)
-    return dict(data=data, months=months)
+    return {"data": data, "months": months}
 
 
 @chart
 def events(today: date) -> IntChartDict:
     months = charts.months(CLUB_BEGIN_ON, today)
     data = charts.per_month(Event.count_by_month, months)
-    return dict(data=data, months=months)
+    return {"data": data, "months": months}
 
 
 @chart
 def events_ttm(today: date) -> IntChartDict:
     months = charts.months(CLUB_BEGIN_ON, today)
     data = charts.per_month(Event.count_by_month_ttm, months)
-    return dict(data=data, months=months)
+    return {"data": data, "months": months}
 
 
 @chart
 def events_women(today: date) -> FloatChartDict:
     months = charts.months(CLUB_BEGIN_ON, today)
     data = charts.per_month(EventSpeaking.women_ptc_ttm, months)
-    return dict(data=data, months=months)
+    return {"data": data, "months": months}
 
 
 @chart
 def podcast_women(today: date) -> FloatChartDict:
     months = charts.months(PODCAST_BEGIN_ON, today)
     data = charts.per_month(PodcastEpisode.women_ptc_ttm, months)
-    return dict(data=data, months=months)
+    return {"data": data, "months": months}
 
 
 @chart
 def members(today: date) -> IntChartDict:
     months = charts.months(MEMBERS_DATA_BEGIN_ON, today)
     data = Members.monthly_members(months)
-    return dict(data=data, months=months)
+    return {"data": data, "months": months}
 
 
 @chart
 def members_individuals(today: date) -> IntChartDict:
     months = charts.months(MEMBERS_DATA_BEGIN_ON, today)
     data = Members.monthly_members_individuals(months)
-    return dict(data=data, months=months)
+    return {"data": data, "months": months}
 
 
 @chart
 def members_individuals_today(today: date) -> ChartDict:
     data = Members.monthly_members_individuals([today])[-1]
-    return dict(data=data)
+    return {"data": data}
 
 
 @chart
@@ -248,84 +249,84 @@ def members_individuals_today_ptc(today: date) -> ChartDict:
     members_individuals_count = Members.monthly_members_individuals([today])[-1]
     members_count = Members.monthly_members([today])[-1]
     data = (members_individuals_count * 100) / members_count
-    return dict(data=data)
+    return {"data": data}
 
 
 @chart
 def members_growth(today: date) -> FloatChartDict:
     months = charts.months(MEMBERS_DATA_BEGIN_ON, today)
     data = Members.monthly_members_growth_ptc(months)
-    return dict(data=data, months=months)
+    return {"data": data, "months": months}
 
 
 @chart
 def members_individuals_growth(today: date) -> FloatChartDict:
     months = charts.months(MEMBERS_DATA_BEGIN_ON, today)
     data = Members.monthly_members_individuals_growth_ptc(months)
-    return dict(data=data, months=months)
+    return {"data": data, "months": months}
 
 
 @chart
 def members_women(today: date) -> FloatChartDict:
     months = charts.months(MEMBERS_DATA_BEGIN_ON, today)
     data = Members.monthly_members_women_ptc(months)
-    return dict(data=data, months=months)
+    return {"data": data, "months": months}
 
 
 @chart
 def members_women_today(today: date) -> ChartDict:
     data = Members.monthly_members_women_ptc([today])[-1]
-    return dict(data=data)
+    return {"data": data}
 
 
 @chart
 def total_marketing_breakdown(today: date) -> FloatBreakdownChartDict:
-    return dict(
-        data=SubscriptionMarketingSurvey.total_breakdown_ptc(),
-        count=SubscriptionMarketingSurvey.count(),
-    )
+    return {
+        "data": SubscriptionMarketingSurvey.total_breakdown_ptc(),
+        "count": SubscriptionMarketingSurvey.count(),
+    }
 
 
 @chart
 def total_spend_marketing_breakdown(today: date) -> FloatBreakdownChartDict:
-    return dict(
-        data=SubscriptionMarketingSurvey.total_spend_breakdown_ptc(),
-        count=SubscriptionMarketingSurvey.count(),
-    )
+    return {
+        "data": SubscriptionMarketingSurvey.total_spend_breakdown_ptc(),
+        "count": SubscriptionMarketingSurvey.count(),
+    }
 
 
 @chart
 def total_referrer_breakdown(today: date) -> FloatBreakdownChartDict:
-    return dict(
-        data=SubscriptionReferrer.total_breakdown_ptc(),
-        count=SubscriptionReferrer.count(),
-    )
+    return {
+        "data": SubscriptionReferrer.total_breakdown_ptc(),
+        "count": SubscriptionReferrer.count(),
+    }
 
 
 @chart
 def total_spend_referrer_breakdown(today: date) -> FloatBreakdownChartDict:
-    return dict(
-        data=SubscriptionReferrer.total_spend_breakdown_ptc(),
-        count=SubscriptionReferrer.count(),
-    )
+    return {
+        "data": SubscriptionReferrer.total_spend_breakdown_ptc(),
+        "count": SubscriptionReferrer.count(),
+    }
 
 
 @chart
 def total_internal_referrer_breakdown(today: date) -> FloatBreakdownChartDict:
     period_days = 30 * 6
-    return dict(
-        data=SubscriptionInternalReferrer.total_breakdown_ptc(period_days),
-        count=SubscriptionInternalReferrer.count(period_days),
-    )
+    return {
+        "data": SubscriptionInternalReferrer.total_breakdown_ptc(period_days),
+        "count": SubscriptionInternalReferrer.count(period_days),
+    }
 
 
 @chart
 def total_spend_internal_referrer_breakdown(today: date) -> FloatBreakdownChartDict:
     period_days = 30 * 6
-    return dict(
-        data=SubscriptionInternalReferrer.total_spend_breakdown_ptc(period_days),
-        count=SubscriptionInternalReferrer.count(period_days),
-    )
+    return {
+        "data": SubscriptionInternalReferrer.total_spend_breakdown_ptc(period_days),
+        "count": SubscriptionInternalReferrer.count(period_days),
+    }
 
 
 @chart
@@ -333,50 +334,50 @@ def cancellations_breakdown(today: date) -> IntBreakdownChartDict:
     months = charts.months(SURVEYS_BEGIN_ON, today)
     data = charts.per_month_breakdown(SubscriptionCancellation.breakdown_ptc, months)
     count = SubscriptionCancellation.count()
-    return dict(data=data, months=months, count=count)
+    return {"data": data, "months": months, "count": count}
 
 
 @chart
 def total_cancellations_breakdown(today: date) -> FloatBreakdownChartDict:
-    return dict(
-        data=SubscriptionCancellation.total_breakdown_ptc(),
-        count=SubscriptionCancellation.count(),
-    )
+    return {
+        "data": SubscriptionCancellation.total_breakdown_ptc(),
+        "count": SubscriptionCancellation.count(),
+    }
 
 
 @chart
 def subscription_types_breakdown(today: date) -> IntBreakdownChartDict:
     months = charts.months(MEMBERS_DATA_BEGIN_ON, today)
     data = Members.monthly_subscription_types_breakdown(months)
-    return dict(data=data, months=months)
+    return {"data": data, "months": months}
 
 
 @chart
 def trials_conversion(today: date) -> FloatChartDict:
     months = charts.months(MEMBERS_DATA_BEGIN_ON, today)
     data = Members.monthly_converting_trials_ptc(months)
-    return dict(data=data, months=months)
+    return {"data": data, "months": months}
 
 
 @chart
 def signups(today: date) -> IntChartDict:
     months = charts.months(MEMBERS_DATA_BEGIN_ON, today)
     data = Members.monthly_signups(months)
-    return dict(data=data, months=months)
+    return {"data": data, "months": months}
 
 
 @chart
 def quits(today: date) -> IntChartDict:
     months = charts.months(MEMBERS_DATA_BEGIN_ON, today)
     data = Members.monthly_quits(months)
-    return dict(data=data, months=months)
+    return {"data": data, "months": months}
 
 
 @chart
 def churn(today: date) -> FloatChartDict:
     months = charts.months(MEMBERS_DATA_BEGIN_ON, today)
     data = Members.monthly_churn_ptc(months)
-    return dict(data=data, months=months)
+    return {"data": data, "months": months}
 
 
 @chart
@@ -386,7 +387,7 @@ def club_content(today: date) -> IntChartDict:
         charts.previous_month(today),
     )
     data = charts.per_month(ClubMessage.content_size_by_month, months)
-    return dict(data=data, months=months)
+    return {"data": data, "months": months}
 
 
 @chart
@@ -396,7 +397,7 @@ def handbook(today: date) -> IntChartDict:
         for page in Page.handbook_listing()
     ]
     data = [page.size for page in Page.handbook_listing()]
-    return dict(data=data, labels=labels)
+    return {"data": data, "labels": labels}
 
 
 @chart
@@ -406,28 +407,28 @@ def handbook_notes(today: date) -> IntChartDict:
         for page in Page.handbook_listing()
     ]
     data = [page.notes_size for page in Page.handbook_listing()]
-    return dict(data=data, labels=labels)
+    return {"data": data, "labels": labels}
 
 
 @chart
 def followers_breakdown(today: date) -> IntBreakdownChartDict:
     months = charts.months(*Followers.months_range())
     data = charts.per_month_breakdown(Followers.breakdown, months)
-    return dict(data=data, months=months)
+    return {"data": data, "months": months}
 
 
 @chart
 def video_followers_breakdown(today: date) -> IntBreakdownChartDict:
     months = charts.months(*Followers.months_range())
     data = charts.per_month_breakdown(Followers.video_breakdown, months)
-    return dict(data=data, months=months)
+    return {"data": data, "months": months}
 
 
 @chart
 def web_usage_total(today: date) -> ChartDict:
     months = charts.months(*WebUsage.months_range())
     breakdown = charts.per_month_breakdown(WebUsage.breakdown, months)
-    return dict(data=breakdown.pop("total"), months=months)
+    return {"data": breakdown.pop("total"), "months": months}
 
 
 @chart
@@ -435,7 +436,7 @@ def web_usage_breakdown(today: date) -> IntBreakdownChartDict:
     months = charts.months(*WebUsage.months_range())
     breakdown = charts.per_month_breakdown(WebUsage.breakdown, months)
     del breakdown["total"]
-    return dict(data=breakdown, months=months)
+    return {"data": breakdown, "months": months}
 
 
 @chart
@@ -454,7 +455,7 @@ def web_club_conversion(today: date) -> FloatChartDict:
             [WebUsage.breakdown(month).get("club") for month in months],
         )
     ]
-    return dict(data=data, months=months)
+    return {"data": data, "months": months}
 
 
 @chart
@@ -471,7 +472,7 @@ def logo_impressions_breakdown(today: date) -> IntBreakdownChartDict:
         for product_name, values in web_usage_breakdown_items
         if product_name in product_names
     }
-    return dict(data=impressions_breakdown)
+    return {"data": impressions_breakdown}
 
 
 @chart
@@ -480,14 +481,14 @@ def jobs_count_listed_discord(today: date) -> IntBreakdownChartDict:
     months, data = charts.per_month_aggregate_breakdown(
         stats,
         day_fn=attrgetter("day"),
-        value_fns=dict(
-            listed=attrgetter("listed_count"),
-            discord=attrgetter("discord_count"),
-        ),
+        value_fns={
+            "listed": attrgetter("listed_count"),
+            "discord": attrgetter("discord_count"),
+        },
         aggregate_fn=charts.average_round,
     )
-    data = dict(listed=data["listed"], discord=data["discord"])
-    return dict(data=data, months=months)
+    data = {"listed": data["listed"], "discord": data["discord"]}
+    return {"data": data, "months": months}
 
 
 @chart
@@ -496,14 +497,14 @@ def jobs_count_listed_dropped(today: date) -> IntBreakdownChartDict:
     months, data = charts.per_month_aggregate_breakdown(
         stats,
         day_fn=attrgetter("day"),
-        value_fns=dict(
-            listed=attrgetter("listed_count"),
-            dropped=attrgetter("dropped_count"),
-        ),
+        value_fns={
+            "listed": attrgetter("listed_count"),
+            "dropped": attrgetter("dropped_count"),
+        },
         aggregate_fn=charts.average_round,
     )
-    data = dict(listed=data["listed"], dropped=data["dropped"])
-    return dict(data=data, months=months)
+    data = {"listed": data["listed"], "dropped": data["dropped"]}
+    return {"data": data, "months": months}
 
 
 @chart
@@ -512,10 +513,10 @@ def jobs_listed_ptc(today: date) -> FloatChartDict:
     months, breakdown = charts.per_month_aggregate_breakdown(
         stats,
         day_fn=attrgetter("day"),
-        value_fns=dict(
-            listed=attrgetter("listed_count"),
-            dropped=attrgetter("dropped_count"),
-        ),
+        value_fns={
+            "listed": attrgetter("listed_count"),
+            "dropped": attrgetter("dropped_count"),
+        },
         aggregate_fn=charts.average_round,
     )
     listed_counts = breakdown["listed"]
@@ -529,21 +530,21 @@ def jobs_listed_ptc(today: date) -> FloatChartDict:
         for listed_count, dropped_count in zip(listed_counts, dropped_counts)
         for total_count in [listed_count + dropped_count]
     ]
-    return dict(data=data, months=months)
+    return {"data": data, "months": months}
 
 
 @chart
 def candidates_listed_breakdown(today: date) -> IntBreakdownChartDict:
     months = charts.months(CANDIDATES_BEGIN_ON, today)
     data = charts.per_month_breakdown(CandidateStats.listed_breakdown, months)
-    return dict(data=data, months=months)
+    return {"data": data, "months": months}
 
 
 @chart
 def candidates_listed_breakdown_ptc(today: date) -> FloatBreakdownChartDict:
     months = charts.months(CANDIDATES_BEGIN_ON, today)
     data = charts.per_month_breakdown(CandidateStats.listed_breakdown_ptc, months)
-    return dict(data=data, months=months)
+    return {"data": data, "months": months}
 
 
 @chart
@@ -553,14 +554,14 @@ def candidates_women(today: date) -> FloatChartDict:
         CandidateStats.listed_breakdown_ptc(month).get("listed_feminine")
         for month in months
     ]
-    return dict(data=data, months=months)
+    return {"data": data, "months": months}
 
 
 @chart
 def candidates_github_checks(today: date) -> IntChartDict:
     months = charts.months(GITHUB_CHECKS_BEGIN_ON, today)
     data = charts.per_month(CandidateStats.checks_count, months)
-    return dict(data=data, months=months)
+    return {"data": data, "months": months}
 
 
 def position(names: list[str], name: str) -> int:
@@ -580,15 +581,15 @@ def countries(today: date) -> ChartDict:
     revenue_breakdown = Transaction.revenue_breakdown(charts.previous_month(today))
     revenue_memberships = revenue_breakdown["memberships"]
 
-    return dict(
-        data=dict(
-            breakdown=breakdown,
-            oss_limit_eur=oss_limit_eur,
-            oss_limit_czk=oss_limit_czk,
-            oss_limit_czk_monthly=int(oss_limit_czk / 12),
-            revenue_memberships=revenue_memberships,
-            revenue_memberships_non_cz=int(
+    return {
+        "data": {
+            "breakdown": breakdown,
+            "oss_limit_eur": oss_limit_eur,
+            "oss_limit_czk": oss_limit_czk,
+            "oss_limit_czk_monthly": int(oss_limit_czk / 12),
+            "revenue_memberships": revenue_memberships,
+            "revenue_memberships_non_cz": int(
                 ((100 - breakdown["CZ"]) * revenue_memberships) / 100
             ),
-        )
-    )
+        }
+    }

--- a/src/jg/coop/sync/club_content/__init__.py
+++ b/src/jg/coop/sync/club_content/__init__.py
@@ -22,11 +22,11 @@ def main():
     discord_task.run(crawl)
 
     with db.connection_context():
-        stats = dict(
-            messages=ClubMessage.count(),
-            users=ClubUser.count(),
-            channels=ClubChannel.count(),
-            members=ClubUser.members_count(),
-            pins=ClubPin.count(),
-        )
+        stats = {
+            "messages": ClubMessage.count(),
+            "users": ClubUser.count(),
+            "channels": ClubChannel.count(),
+            "members": ClubUser.members_count(),
+            "pins": ClubPin.count(),
+        }
     logger.info(f"Finished with\n{pformat(stats)}")

--- a/src/jg/coop/sync/club_content/crawler.py
+++ b/src/jg/coop/sync/club_content/crawler.py
@@ -1,6 +1,6 @@
 import asyncio
+from collections.abc import AsyncGenerator
 from datetime import datetime, timedelta, timezone
-from typing import AsyncGenerator
 
 from discord import ChannelType, DMChannel, Member, Message, Reaction, User
 from discord.abc import GuildChannel

--- a/src/jg/coop/sync/course_providers.py
+++ b/src/jg/coop/sync/course_providers.py
@@ -1,8 +1,8 @@
 import math
+from collections.abc import Callable
 from datetime import date, timedelta
 from functools import wraps
 from pathlib import Path
-from typing import Callable
 
 import httpx
 import yaml
@@ -102,13 +102,13 @@ def main():
         ("page_last_month_pageviews", 30),
     ]:
         logger.info(f"Fetching analytics: {metric_name}")
-        params = dict(
-            version=5,
-            fields="pageviews,pages",
-            info="false",
-            page="/courses/*",
-            start=str(date.today() - timedelta(days=days)),
-        )
+        params = {
+            "version": 5,
+            "fields": "pageviews,pages",
+            "info": "false",
+            "page": "/courses/*",
+            "start": str(date.today() - timedelta(days=days)),
+        }
         response = httpx.get(
             "https://simpleanalytics.com/junior.guru.json", params=params
         )

--- a/src/jg/coop/sync/events.py
+++ b/src/jg/coop/sync/events.py
@@ -200,7 +200,7 @@ def main(
             event.save()
 
             logger.info(f"Rendering posters for {event_config.title!r}")
-            filters = dict(local_time=local_time, weekday=weekday, icon=icon)
+            filters = {"local_time": local_time, "weekday": weekday, "icon": icon}
             date_prefix = event.start_at.date().isoformat().replace("-", "")
             for event_property, context, prefix in [
                 (

--- a/src/jg/coop/sync/feminine_names.py
+++ b/src/jg/coop/sync/feminine_names.py
@@ -72,8 +72,8 @@ def main():
         logger.info(f"{name} → {name_lower}, {name_ascii}")
         FeminineName.insert_many(
             [
-                dict(name=name_lower),
-                dict(name=name_ascii),
+                {"name": name_lower},
+                {"name": name_ascii},
             ]
         ).on_conflict_ignore().execute()
 

--- a/src/jg/coop/sync/guide_dashboard.py
+++ b/src/jg/coop/sync/guide_dashboard.py
@@ -63,9 +63,9 @@ def main(channel_id: int, cache_key: str, cache_days: int, force: bool):
 
 async def sync_channel(client: ClubClient, channel_id: int, tips: list[Tip]):
     message_args_list = [
-        dict(content=HEADER_MESSAGE, embeds=[], suppress=True),
-        dict(content=LINKS_MESSAGE, embeds=[], view=build_links_view()),
-        dict(content=TIPS_HEADER_MESSAGE, embeds=[], suppress=True),
+        {"content": HEADER_MESSAGE, "embeds": [], "suppress": True},
+        {"content": LINKS_MESSAGE, "embeds": [], "view": build_links_view()},
+        {"content": TIPS_HEADER_MESSAGE, "embeds": [], "suppress": True},
         *(build_tip_args(tip) for tip in tips),
     ]
     await sync_guide_channel(client, channel_id, message_args_list)
@@ -78,7 +78,7 @@ def build_tip_args(tip: Tip) -> dict:
         description=tip.lead,
     )
     embed.set_thumbnail(url=emoji_url(tip.emoji))
-    return dict(embed=embed)
+    return {"embed": embed}
 
 
 def build_links_view() -> ui.View:

--- a/src/jg/coop/sync/guide_events.py
+++ b/src/jg/coop/sync/guide_events.py
@@ -76,8 +76,8 @@ def build_event_args(event: Event) -> dict:
         )
     )
 
-    return dict(
-        embed=embed,
-        files=[File(IMAGES_DIR / event.avatar_path)],
-        view=view,
-    )
+    return {
+        "embed": embed,
+        "files": [File(IMAGES_DIR / event.avatar_path)],
+        "view": view,
+    }

--- a/src/jg/coop/sync/guide_roles.py
+++ b/src/jg/coop/sync/guide_roles.py
@@ -72,4 +72,4 @@ def build_role_args(role: DocumentedRole) -> dict:
         embed.set_thumbnail(url=emoji_url(role.emoji))
     else:
         logger.debug(f"Setting no thumbnail, role.icon_path is {role.icon_path!r}")
-    return dict(embed=embed, file=file)
+    return {"embed": embed, "file": file}

--- a/src/jg/coop/sync/guide_sponsors.py
+++ b/src/jg/coop/sync/guide_sponsors.py
@@ -46,8 +46,8 @@ async def sync_channel(client: ClubClient, channel_id: int, sponsors: list[Spons
 
 
 def build_header_args() -> dict:
-    return dict(
-        content=(
+    return {
+        "content": (
             "# Seznam sponzorů\n\n"
             "Tyto organizace se podílejí na financování junior.guru. "
             "Můžeš se tady prokliknout na jejich stránky. "
@@ -57,10 +57,10 @@ def build_header_args() -> dict:
             "Role využívej a sponzory klidně označ, pokud po nich něco potřebuješ. "
             "Seznam sponzorů je tady seřazený podle počtu jejich lidí v klubu. "
         ),
-        embeds=[],
-        suppress=True,
-        allowed_mentions=AllowedMentions.none(),
-    )
+        "embeds": [],
+        "suppress": True,
+        "allowed_mentions": AllowedMentions.none(),
+    }
 
 
 def build_sponsor_args(sponsor: Sponsor) -> dict:
@@ -71,8 +71,8 @@ def build_sponsor_args(sponsor: Sponsor) -> dict:
         description=f"Role: <@&{sponsor.role_id}>\nČlenů: {sponsor.members_count}",
     )
     embed.set_thumbnail(url=f"attachment://{Path(sponsor.poster_path).name}")
-    return dict(
-        embed=embed,
-        files=[File(IMAGES_DIR / sponsor.poster_path)],
-        allowed_mentions=AllowedMentions.none(),
-    )
+    return {
+        "embed": embed,
+        "files": [File(IMAGES_DIR / sponsor.poster_path)],
+        "allowed_mentions": AllowedMentions.none(),
+    }

--- a/src/jg/coop/sync/jobs_club.py
+++ b/src/jg/coop/sync/jobs_club.py
@@ -380,10 +380,10 @@ async def prepare_thread_params(job: ListedJob) -> dict:
         )
         embeds.append(reason_embed)
 
-    return dict(
-        name=job.title_short,
-        content=content,
-        files=files,
-        embeds=embeds,
-        view=ui.View(ui.Button(emoji="👉", label="Celý inzerát", url=job.url)),
-    )
+    return {
+        "name": job.title_short,
+        "content": content,
+        "files": files,
+        "embeds": embeds,
+        "view": ui.View(ui.Button(emoji="👉", label="Celý inzerát", url=job.url)),
+    }

--- a/src/jg/coop/sync/jobs_scraped/__init__.py
+++ b/src/jg/coop/sync/jobs_scraped/__init__.py
@@ -1,8 +1,8 @@
 import asyncio
 import importlib
 import itertools
+from collections.abc import Awaitable, Callable
 from pprint import pformat
-from typing import Awaitable, Callable
 
 from peewee import IntegrityError
 
@@ -93,20 +93,20 @@ async def main():
 
 def transform_linkedin_item(item: dict) -> dict:
     try:
-        return dict(
-            title=item["title"],
-            posted_on=item["postedAt"][:10],
-            url=item["link"],
-            apply_url=item.get("applyUrl") or None,
-            company_name=item["companyName"],
-            company_url=item.get("companyWebsite"),
-            company_logo_urls=[item["companyLogo"]],
-            locations_raw=[item["location"]],
-            employment_types=[item.get("employmentType", "Full-time")],
-            description_html=item.get("descriptionHtml", item["descriptionText"]),
-            source="jobs-linkedin",
-            source_urls=[item["inputUrl"]],
-        )
+        return {
+            "title": item["title"],
+            "posted_on": item["postedAt"][:10],
+            "url": item["link"],
+            "apply_url": item.get("applyUrl") or None,
+            "company_name": item["companyName"],
+            "company_url": item.get("companyWebsite"),
+            "company_logo_urls": [item["companyLogo"]],
+            "locations_raw": [item["location"]],
+            "employment_types": [item.get("employmentType", "Full-time")],
+            "description_html": item.get("descriptionHtml", item["descriptionText"]),
+            "source": "jobs-linkedin",
+            "source_urls": [item["inputUrl"]],
+        }
     except Exception as e:
         if error := item.get("error"):
             raise RuntimeError(error)

--- a/src/jg/coop/sync/members/__init__.py
+++ b/src/jg/coop/sync/members/__init__.py
@@ -1,11 +1,12 @@
 import math
 from collections import defaultdict
+from collections.abc import Iterable
 from datetime import date, datetime
 from enum import StrEnum
 from operator import itemgetter
 from pathlib import Path
 from pprint import pformat
-from typing import DefaultDict, Iterable, Literal, TypedDict
+from typing import Literal, TypedDict
 
 import click
 from discord import NotFound
@@ -99,7 +100,7 @@ def main(history_path: Path, today: date):
 
     stats_from = today.replace(day=1)
     stats_to = today
-    stats: DefaultDict[StatName, int] = defaultdict(int)
+    stats: defaultdict[StatName, int] = defaultdict(int)
 
     for account in logger.progress(accounts):
         account_id = int(account["id"])

--- a/src/jg/coop/sync/newsletter/__init__.py
+++ b/src/jg/coop/sync/newsletter/__init__.py
@@ -1,10 +1,11 @@
 import random
 import time
+from collections.abc import Generator
 from datetime import date
 from operator import itemgetter
 from pathlib import Path
 from pprint import pformat
-from typing import Generator, Literal
+from typing import Literal
 
 import click
 from jinja2 import Template
@@ -259,31 +260,31 @@ async def create_newsletter_draft(
 
     logger.debug("Rendering email body")
     template = Template(Path(__file__).with_name("newsletter.jinja").read_text())
-    template_context = dict(
-        club_content_size=thousands(ClubMessage.content_size_by_month(prev_month)),
-        club_creations=club_creations,
-        club_cv_reviews=club_cv_reviews,
-        club_diaries=club_diaries,
-        club_groups=club_groups,
-        club_promo_events=club_promo_events,
-        course_providers_by_mentions=course_providers_by_mentions,
-        course_providers=course_providers,
-        event_last=event_last,
-        event_random=event_random,
-        events_planned=events_planned,
-        jobs_count=jobs_count,
-        jobs_tags_stats=jobs_tags_stats,
-        meetups=meetups,
-        members_count=ClubUser.members_count(),
-        podcast_last=podcast_last,
-        podcast_random=podcast_random,
-        prev_month=prev_month,
-        story_last=story_last,
-        story_random=story_random,
-        subscribers_count=subscribers_count,
-        subscribers_new_count=subscribers_new_count,
-        topics=topics,
-    )
+    template_context = {
+        "club_content_size": thousands(ClubMessage.content_size_by_month(prev_month)),
+        "club_creations": club_creations,
+        "club_cv_reviews": club_cv_reviews,
+        "club_diaries": club_diaries,
+        "club_groups": club_groups,
+        "club_promo_events": club_promo_events,
+        "course_providers_by_mentions": course_providers_by_mentions,
+        "course_providers": course_providers,
+        "event_last": event_last,
+        "event_random": event_random,
+        "events_planned": events_planned,
+        "jobs_count": jobs_count,
+        "jobs_tags_stats": jobs_tags_stats,
+        "meetups": meetups,
+        "members_count": ClubUser.members_count(),
+        "podcast_last": podcast_last,
+        "podcast_random": podcast_random,
+        "prev_month": prev_month,
+        "story_last": story_last,
+        "story_random": story_random,
+        "subscribers_count": subscribers_count,
+        "subscribers_new_count": subscribers_new_count,
+        "topics": topics,
+    }
     logger.debug(f"Template context:\n{pformat(template_context)}")
     month_name = f"{MONTH_NAMES[prev_month.month - 1]} {prev_month.year}"
     email_data = {

--- a/src/jg/coop/sync/newsletter_subscribers/__init__.py
+++ b/src/jg/coop/sync/newsletter_subscribers/__init__.py
@@ -1,7 +1,8 @@
 import asyncio
+from collections.abc import Generator
 from datetime import date
 from pathlib import Path
-from typing import Generator, TypedDict
+from typing import TypedDict
 
 import click
 

--- a/src/jg/coop/sync/organizations/__init__.py
+++ b/src/jg/coop/sync/organizations/__init__.py
@@ -1,8 +1,9 @@
 import re
+from collections.abc import Iterable
 from datetime import date, timedelta
 from operator import itemgetter
 from pathlib import Path
-from typing import Annotated, Any, Iterable, Literal, TypedDict
+from typing import Annotated, Any, Literal, TypedDict
 
 import click
 import yaml
@@ -49,8 +50,8 @@ POSTERS_DIR = IMAGES_DIR / "posters-sponsors"
 POSTER_SIZE = 700
 
 TIERS_EXTRAS = {
-    "Budujeme brand": dict(max_sponsors=4, courses_highlight=True),
-    "Poskytujeme kurzy": dict(courses_highlight=True),
+    "Budujeme brand": {"max_sponsors": 4, "courses_highlight": True},
+    "Poskytujeme kurzy": {"courses_highlight": True},
 }
 
 
@@ -195,7 +196,7 @@ def main(today: date, clear_posters: bool):
             elif sponsor.subscription:
                 subscription_id = parse_subscription_id(sponsor.subscription)
                 subscription = memberful.get(
-                    SUBSCRIPTION_GQL_PATH.read_text(), dict(id=subscription_id)
+                    SUBSCRIPTION_GQL_PATH.read_text(), {"id": subscription_id}
                 )["subscription"]
                 plan_id = get_plan_id(subscription)
                 tier = tiers_by_plan_id[plan_id]
@@ -215,11 +216,11 @@ def main(today: date, clear_posters: bool):
                 POSTER_SIZE,
                 POSTER_SIZE,
                 "sponsor.jinja",
-                dict(
-                    sponsor_name=sponsor.name,
-                    sponsor_logo_path=logo_path,
-                    tier_priority=tier.priority,
-                ),
+                {
+                    "sponsor_name": sponsor.name,
+                    "sponsor_logo_path": logo_path,
+                    "tier_priority": tier.priority,
+                },
                 POSTERS_DIR,
                 prefix=sponsor.slug,
             )
@@ -276,7 +277,7 @@ def main(today: date, clear_posters: bool):
             elif partner.subscription:
                 subscription_id = parse_subscription_id(partner.subscription)
                 subscription = memberful.get(
-                    SUBSCRIPTION_GQL_PATH.read_text(), dict(id=subscription_id)
+                    SUBSCRIPTION_GQL_PATH.read_text(), {"id": subscription_id}
                 )["subscription"]
                 plan_id = get_plan_id(subscription)
                 account_ids = get_account_ids(subscription)
@@ -322,12 +323,12 @@ def get_account_ids(subscription: SubscriptionEntity) -> list[int]:
 
 
 def get_tier_data(plan: PlanEntity) -> dict[str, Any]:
-    return dict(
-        plan_id=int(plan["id"]),
-        name=parse_tier_name(plan["name"]),
-        price=from_cents(plan["priceCents"]),
-        member_price=from_cents(plan["additionalMemberPriceCents"]) or None,
-    )
+    return {
+        "plan_id": int(plan["id"]),
+        "name": parse_tier_name(plan["name"]),
+        "price": from_cents(plan["priceCents"]),
+        "member_price": from_cents(plan["additionalMemberPriceCents"]) or None,
+    }
 
 
 def prepare_tiers(

--- a/src/jg/coop/sync/podcast.py
+++ b/src/jg/coop/sync/podcast.py
@@ -152,21 +152,21 @@ def process_episode(yaml_record):
         raise ValueError(f"Episode #{number} is missing guest_name")
 
     logger_ep.debug("Preparing data")
-    data = dict(
-        number=number,
-        publish_on=yaml_record["publish_on"],
-        title=yaml_record["title"],
-        guest_name=guest_name,
-        guest_has_feminine_name=guest_has_feminine_name,
-        guest_affiliation=guest_affiliation,
-        image_path=image_path,
-        description=yaml_record["description"],
-        media_slug=media_slug,
-        media_url=media_url,
-        media_size=media_size,
-        media_type=media_type,
-        media_duration_s=media_duration_s,
-    )
+    data = {
+        "number": number,
+        "publish_on": yaml_record["publish_on"],
+        "title": yaml_record["title"],
+        "guest_name": guest_name,
+        "guest_has_feminine_name": guest_has_feminine_name,
+        "guest_affiliation": guest_affiliation,
+        "image_path": image_path,
+        "description": yaml_record["description"],
+        "media_slug": media_slug,
+        "media_url": media_url,
+        "media_size": media_size,
+        "media_type": media_type,
+        "media_duration_s": media_duration_s,
+    }
 
     logger_ep.debug("Rendering poster")
     podcast_episode = PodcastEpisode(**data)
@@ -176,7 +176,7 @@ def process_episode(yaml_record):
     # the image renderer with a populated Peewee model object, so let's drop
     # the contents.
     podcast_episode.clear_dirty_fields()
-    tpl_context = dict(podcast_episode=podcast_episode)
+    tpl_context = {"podcast_episode": podcast_episode}
     poster_path = render_image_file(
         POSTER_WIDTH,
         POSTER_HEIGHT,
@@ -184,7 +184,7 @@ def process_episode(yaml_record):
         tpl_context,
         POSTERS_DIR,
         prefix=media_slug,
-        filters=dict(icon=icon),
+        filters={"icon": icon},
     )
     data["poster_path"] = poster_path.relative_to(IMAGES_DIR)
 

--- a/src/jg/coop/sync/roles.py
+++ b/src/jg/coop/sync/roles.py
@@ -1,8 +1,8 @@
 import itertools
 from collections import Counter
+from collections.abc import Iterable
 from pathlib import Path
 from pprint import pformat
-from typing import Iterable
 
 import yaml
 from discord import Color, Role
@@ -333,7 +333,7 @@ async def apply_changes(client: ClubClient, changes):
         if role_id is None:
             logger.error(f"Cannot {op} role for #{member_id}: role_id not created yet")
         else:
-            changes_by_members.setdefault(member_id, dict(add=[], remove=[]))
+            changes_by_members.setdefault(member_id, {"add": [], "remove": []})
             changes_by_members[member_id][op].append(role_id)
 
     for member_id, changes in changes_by_members.items():

--- a/src/jg/coop/sync/subscriptions_align.py
+++ b/src/jg/coop/sync/subscriptions_align.py
@@ -32,7 +32,10 @@ def main():
             renews_on = getattr(org, "renews_on", today + timedelta(days=365))
             logger.info(f"Organization {org.slug!r} renews on {renews_on}")
             renews_at = datetime.combine(renews_on, time(tzinfo=timezone.utc))
-            params = dict(id=org.subscription_id, expiresAt=int(renews_at.timestamp()))
+            params = {
+                "id": org.subscription_id,
+                "expiresAt": int(renews_at.timestamp()),
+            }
             logger.debug(f"Updating organization {org.slug!r} to renew at {renews_at}")
             if align_subscription(memberful, mutation, params):
                 logger.info(

--- a/src/jg/coop/sync/subscriptions_country.py
+++ b/src/jg/coop/sync/subscriptions_country.py
@@ -57,8 +57,8 @@ def fetch_customer_data(customer: stripe.Customer) -> str:
         country_code = payment_methods.data[0].card.country
     except IndexError:
         country_code = None
-    return dict(
-        id=customer.id,
-        email=customer.email,
-        country_code=country_code,
-    )
+    return {
+        "id": customer.id,
+        "email": customer.email,
+        "country_code": country_code,
+    }

--- a/src/jg/coop/sync/subscriptions_csv/__init__.py
+++ b/src/jg/coop/sync/subscriptions_csv/__init__.py
@@ -83,12 +83,12 @@ def main(error_channel_id: int):
 
             referrer = csv_row["Referrer"] or None
             if referrer:
-                account_details = dict(
-                    account_id=account_id,
-                    account_name=csv_row["Full Name"],
-                    account_email=csv_row["Email"],
-                    account_total_spend=total_spend[account_id],
-                )
+                account_details = {
+                    "account_id": account_id,
+                    "account_name": csv_row["Full Name"],
+                    "account_email": csv_row["Email"],
+                    "account_total_spend": total_spend[account_id],
+                }
                 created_on = date.fromisoformat(csv_row["Created at"])
                 referrer_type = classify_referrer(referrer)
                 if referrer_type.startswith("/"):

--- a/src/jg/coop/sync/thumbnails.py
+++ b/src/jg/coop/sync/thumbnails.py
@@ -56,7 +56,7 @@ def main(images_path, output_dir, width, height, clear):
 def process_thumbnail(args: tuple[int, int, int, str, dict, Path]) -> tuple[int, Path]:
     i, args = args[0], args[1:]
     image_path = render_image_file(
-        *args, filters=dict(local_time=local_time, weekday=weekday, icon=icon)
+        *args, filters={"local_time": local_time, "weekday": weekday, "icon": icon}
     )
     return i, image_path
 
@@ -70,25 +70,25 @@ def get_thumbnail_context(page: Page) -> dict:
         "Inspirace": "rocket-takeoff",
         "Info": "info-circle",
     }.get(page.mainnav_name, "arrow-right-circle")
-    return dict(
-        title=page.meta.get("thumbnail_title", page.meta["title"]),
-        image_path=page.meta.get("thumbnail_image_path", "chick-avatar.png"),
-        date=(
+    return {
+        "title": page.meta.get("thumbnail_title", page.meta["title"]),
+        "image_path": page.meta.get("thumbnail_image_path", "chick-avatar.png"),
+        "date": (
             datetime.fromisoformat(page.meta["thumbnail_date"])
             if page.meta.get("thumbnail_date")
             else None
         ),
-        subheading=page.meta.get(
+        "subheading": page.meta.get(
             "thumbnail_subheading", f"junior.guru — {page.mainnav_name}"
         ),
-        button_heading=page.meta.get("thumbnail_button_heading"),
-        button_icon=(
+        "button_heading": page.meta.get("thumbnail_button_heading"),
+        "button_icon": (
             None
             if page.meta.get("thumbnail_button_heading")
             else (page.meta.get("thumbnail_button_icon", default_button_icon))
         ),
-        button_link=page.meta.get(
+        "button_link": page.meta.get(
             "thumbnail_button_link", f"junior.guru/{page.dest_uri.split('/')[0]}"
         ),
-        platforms=page.meta.get("thumbnail_platforms", []),
-    )
+        "platforms": page.meta.get("thumbnail_platforms", []),
+    }

--- a/src/jg/coop/sync/tips.py
+++ b/src/jg/coop/sync/tips.py
@@ -95,7 +95,7 @@ def parse_tip(markdown: str, roles: dict[str, int] | None = None) -> dict:
     except Exception as e:
         raise ValueError("Could not parse lead") from e
 
-    return dict(emoji=emoji, title=title, lead=lead, content=markdown)
+    return {"emoji": emoji, "title": title, "lead": lead, "content": markdown}
 
 
 @db.connection_context()

--- a/src/jg/coop/sync/transactions/__init__.py
+++ b/src/jg/coop/sync/transactions/__init__.py
@@ -1,8 +1,8 @@
 import re
+from collections.abc import Callable
 from datetime import date, datetime, timedelta
 from pathlib import Path
 from pprint import pformat
-from typing import Callable
 
 import click
 import httpx
@@ -82,7 +82,7 @@ def main(
         )
         if not confirm("Continue anyway?"):
             raise click.Abort()
-    secrets = dict(video_outsourcing_token=video_outsourcing_token)
+    secrets = {"video_outsourcing_token": video_outsourcing_token}
 
     logger.info("Preparing database")
     Transaction.drop_table()
@@ -94,7 +94,7 @@ def main(
     with fakturoid.get_client(fakturoid_token) as client:
         while True:
             logger.debug(f"Fakturoid todos, page {page}")
-            response = client.get("/todos.json", params=dict(page=page))
+            response = client.get("/todos.json", params={"page": page})
             response.raise_for_status()
             todos_page = response.json()
             todos.extend(
@@ -155,12 +155,12 @@ def main(
         logger.debug(f"Category: {category!r}")
         if category != TransactionsCategory.IGNORE:
             db_records.append(
-                dict(
-                    id=transaction["transaction_id"],
-                    happened_on=transaction["date"],
-                    category=category,
-                    amount=transaction["amount"],
-                )
+                {
+                    "id": transaction["transaction_id"],
+                    "happened_on": transaction["date"],
+                    "category": category,
+                    "amount": transaction["amount"],
+                }
             )
         if (
             transaction["amount"] > 0

--- a/src/jg/coop/sync/transactions/categories_spec.py
+++ b/src/jg/coop/sync/transactions/categories_spec.py
@@ -1,5 +1,5 @@
+from collections.abc import Callable
 from datetime import date
-from typing import Callable
 
 from jg.coop.models.transaction import TransactionsCategory
 

--- a/src/jg/coop/sync/web_usage.py
+++ b/src/jg/coop/sync/web_usage.py
@@ -69,7 +69,7 @@ def main():
     date_to = date.today()
     date_from = date_to - timedelta(days=30 * MONTHS_RANGE)
     time_ranges = [
-        dict(start=month.replace(day=1).isoformat(), end=month.isoformat())
+        {"start": month.replace(day=1).isoformat(), "end": month.isoformat()}
         for month in charts.generate_months(date_from, date_to)
     ][:MONTHS_RANGE]
 

--- a/src/jg/coop/web/generators.py
+++ b/src/jg/coop/web/generators.py
@@ -1,6 +1,7 @@
 from collections import Counter
+from collections.abc import Generator
 from pathlib import Path
-from typing import Any, Generator
+from typing import Any
 
 import mkdocs_gen_files
 import yaml
@@ -62,11 +63,11 @@ def generate_redirects() -> Generator[GeneratedDocument, None, None]:
     for redirect in config.registry:
         yield GeneratedDocument(
             path=redirect.from_doc,
-            meta=dict(
-                title="Přesměrování",
-                template="redirect.html",
-                redirect=redirect.to_doc,
-            ),
+            meta={
+                "title": "Přesměrování",
+                "template": "redirect.html",
+                "redirect": redirect.to_doc,
+            },
             content=(DOCS_DIR / "redirect.jinja").read_text(),
         )
 
@@ -78,15 +79,15 @@ def generate_region_jobs_pages() -> Generator[GeneratedDocument, None, None]:
     yield GeneratedDocument(
         path=f"jobs/{REMOTE_TAG_SLUG}.jinja",
         meta=meta
-        | dict(
-            title=f"{meta['title']}: na dálku, z domova, remote",
-            description=(
+        | {
+            "title": f"{meta['title']}: na dálku, z domova, remote",
+            "description": (
                 "Pracovní příležitosti pro začátečníky v IT, "
                 f"které jsou na dálku, z domova, remote. {meta['description']}"
             ),
-            region="na dálku",
-            region_tag_slug=REMOTE_TAG_SLUG,
-        ),
+            "region": "na dálku",
+            "region_tag_slug": REMOTE_TAG_SLUG,
+        },
         content=content,
     )
     for region in REGIONS:
@@ -95,12 +96,12 @@ def generate_region_jobs_pages() -> Generator[GeneratedDocument, None, None]:
         yield GeneratedDocument(
             path=f"jobs/{doc_slug}.jinja",
             meta=meta
-            | dict(
-                title=f"{meta['title']}: {region}",
-                description=f"Jaké nabízí {region} příležitosti pro začátečníky v IT? {meta['description']}",
-                region=region,
-                region_tag_slug=tag_slug,
-            ),
+            | {
+                "title": f"{meta['title']}: {region}",
+                "description": f"Jaké nabízí {region} příležitosti pro začátečníky v IT? {meta['description']}",
+                "region": region,
+                "region_tag_slug": tag_slug,
+            },
             content=content,
         )
 
@@ -110,18 +111,18 @@ def generate_job_pages() -> Generator[GeneratedDocument, None, None]:
     for job in ListedJob.submitted_listing():
         yield GeneratedDocument(
             path=f"jobs/{job.submitted_job.id}.jinja",
-            meta=dict(
-                title=f"{job.title_short} – {job.company_name} – {job.location_text or '?'}",
-                description=(
+            meta={
+                "title": f"{job.title_short} – {job.company_name} – {job.location_text or '?'}",
+                "description": (
                     f"Pracovní nabídka pro začínající programátory: "
                     f"{job.title} – {job.company_name}, {job.location_text or '?'}"
                 ),
-                job_id=job.submitted_job.id,
-                job_company_name=job.company_name,
-                job_apply_url=job.apply_url or "",
-                job_apply_email=job.apply_email or "",
-                template="main_job.html",
-            ),
+                "job_id": job.submitted_job.id,
+                "job_company_name": job.company_name,
+                "job_apply_url": job.apply_url or "",
+                "job_apply_email": job.apply_email or "",
+                "template": "main_job.html",
+            },
             content=(DOCS_DIR / "job.jinja").read_text(),
         )
 
@@ -160,23 +161,23 @@ def generate_podcast_episode_pages() -> Generator[GeneratedDocument, None, None]
     for podcast_episode in PodcastEpisode.listing():
         yield GeneratedDocument(
             path=f"podcast/{podcast_episode.number}.jinja",
-            meta=dict(
-                title=f"Podcast – {podcast_episode.format_title()}",
-                description=f"Poslechni si {podcast_episode.number}. díl Junior Guru podcastu.",
-                podcast_episode_number=podcast_episode.number,
-                breadcrumb_parent="Podcast",
-                breadcrumb_item=(
+            meta={
+                "title": f"Podcast – {podcast_episode.format_title()}",
+                "description": f"Poslechni si {podcast_episode.number}. díl Junior Guru podcastu.",
+                "podcast_episode_number": podcast_episode.number,
+                "breadcrumb_parent": "Podcast",
+                "breadcrumb_item": (
                     podcast_episode.guest_name or f"Epizoda {podcast_episode.number}"
                 ),
-                thumbnail_title=podcast_episode.format_title(affiliation=False),
-                thumbnail_subheading=f"Epizoda {podcast_episode.number}",
-                thumbnail_image_path=podcast_episode.image_path,
-                thumbnail_button_heading="Poslouchej na",
-                thumbnail_button_link="junior.guru/podcast",
-                thumbnail_platforms=["youtube", "spotify", "apple"],
-                comments_heading="Máš otázky? Chceš probrat podobná témata?",
-                template="main_content_detail.html",
-            ),
+                "thumbnail_title": podcast_episode.format_title(affiliation=False),
+                "thumbnail_subheading": f"Epizoda {podcast_episode.number}",
+                "thumbnail_image_path": podcast_episode.image_path,
+                "thumbnail_button_heading": "Poslouchej na",
+                "thumbnail_button_link": "junior.guru/podcast",
+                "thumbnail_platforms": ["youtube", "spotify", "apple"],
+                "comments_heading": "Máš otázky? Chceš probrat podobná témata?",
+                "template": "main_content_detail.html",
+            },
             content=(DOCS_DIR / "podcast_episode.jinja").read_text(),
         )
 
@@ -186,12 +187,12 @@ def generate_course_provider_pages() -> Generator[GeneratedDocument, None, None]
     for course_provider in CourseProvider.listing():
         yield GeneratedDocument(
             path=f"courses/{course_provider.slug}.md",
-            meta=dict(
-                title=course_provider.page_title,
-                description=course_provider.page_description,
-                course_provider_slug=course_provider.slug,
-                topic_mention_id=course_provider.slug,
-            ),
+            meta={
+                "title": course_provider.page_title,
+                "description": course_provider.page_description,
+                "course_provider_slug": course_provider.slug,
+                "topic_mention_id": course_provider.slug,
+            },
             content=(DOCS_DIR / "course_provider.md").read_text(),
         )
 
@@ -201,18 +202,18 @@ def generate_newsletter_issue_pages() -> Generator[GeneratedDocument, None, None
     for newsletter_issue in NewsletterIssue.listing():
         yield GeneratedDocument(
             path=f"news/{newsletter_issue.slug}.md",
-            meta=dict(
-                title=newsletter_issue.subject,
-                description="Začínáš v IT? V tomhle newsletteru najdeš pozvánky, kurzy, podcasty, přednášky, články a další zdroje, které tě posunou a namotivují.",
-                date=newsletter_issue.published_on.isoformat(),
-                newsletter_issue_id=newsletter_issue.id,
-                template="main_subnav.html",
-                thumbnail_title=newsletter_issue.subject,
-                thumbnail_subheading="Newsletter",
-                thumbnail_date=newsletter_issue.published_on.isoformat(),
-                thumbnail_button_heading="Čti na",
-                thumbnail_button_link="junior.guru/news",
-            ),
+            meta={
+                "title": newsletter_issue.subject,
+                "description": "Začínáš v IT? V tomhle newsletteru najdeš pozvánky, kurzy, podcasty, přednášky, články a další zdroje, které tě posunou a namotivují.",
+                "date": newsletter_issue.published_on.isoformat(),
+                "newsletter_issue_id": newsletter_issue.id,
+                "template": "main_subnav.html",
+                "thumbnail_title": newsletter_issue.subject,
+                "thumbnail_subheading": "Newsletter",
+                "thumbnail_date": newsletter_issue.published_on.isoformat(),
+                "thumbnail_button_heading": "Čti na",
+                "thumbnail_button_link": "junior.guru/news",
+            },
             content=(DOCS_DIR / "newsletter_issue.md").read_text(),
         )
 

--- a/tests/sync_jobs_logos/test_jobs_logos.py
+++ b/tests/sync_jobs_logos/test_jobs_logos.py
@@ -16,14 +16,14 @@ def _debug(image):
 
 @pytest.fixture
 def logo_image_data() -> dict:
-    return dict(
-        image_url="https://apify.example.com/kvs/image.webp",
-        original_image_url="https://example.com/image.webp",
-        width=SIZE_PX,
-        height=SIZE_PX,
-        format="webp",
-        source_url="https://example.com",
-    )
+    return {
+        "image_url": "https://apify.example.com/kvs/image.webp",
+        "original_image_url": "https://example.com/image.webp",
+        "width": SIZE_PX,
+        "height": SIZE_PX,
+        "format": "webp",
+        "source_url": "https://example.com",
+    }
 
 
 def test_company_logo_convert_image_has_expected_size():
@@ -48,13 +48,13 @@ def test_sort_key_prefers_logo_over_icon(logo_image_data: dict):
 def test_sort_key_treats_small_images_like_squares(logo_image_data: dict):
     key1 = sort_key(
         Logo(
-            image=logo_image_data | dict(width=1, height=16),
+            image=logo_image_data | {"width": 1, "height": 16},
             source_type=LogoSourceType.ICON,
         )
     )
     key2 = sort_key(
         Logo(
-            image=logo_image_data | dict(width=4, height=4),
+            image=logo_image_data | {"width": 4, "height": 4},
             source_type=LogoSourceType.ICON,
         )
     )
@@ -65,13 +65,13 @@ def test_sort_key_treats_small_images_like_squares(logo_image_data: dict):
 def test_sort_key_prefers_squares(logo_image_data: dict):
     key1 = sort_key(
         Logo(
-            image=logo_image_data | dict(width=100, height=1600),
+            image=logo_image_data | {"width": 100, "height": 1600},
             source_type=LogoSourceType.LOGO,
         )
     )
     key2 = sort_key(
         Logo(
-            image=logo_image_data | dict(width=400, height=400),
+            image=logo_image_data | {"width": 400, "height": 400},
             source_type=LogoSourceType.LOGO,
         )
     )
@@ -82,13 +82,13 @@ def test_sort_key_prefers_squares(logo_image_data: dict):
 def test_sort_key_prefers_square_like_rectangles(logo_image_data: dict):
     key1 = sort_key(
         Logo(
-            image=logo_image_data | dict(width=100, height=1600),
+            image=logo_image_data | {"width": 100, "height": 1600},
             source_type=LogoSourceType.LOGO,
         )
     )
     key2 = sort_key(
         Logo(
-            image=logo_image_data | dict(width=305, height=300),
+            image=logo_image_data | {"width": 305, "height": 300},
             source_type=LogoSourceType.LOGO,
         )
     )
@@ -99,13 +99,13 @@ def test_sort_key_prefers_square_like_rectangles(logo_image_data: dict):
 def test_sort_key_prefers_larger_images(logo_image_data: dict):
     key1 = sort_key(
         Logo(
-            image=logo_image_data | dict(width=500, height=500),
+            image=logo_image_data | {"width": 500, "height": 500},
             source_type=LogoSourceType.LOGO,
         )
     )
     key2 = sort_key(
         Logo(
-            image=logo_image_data | dict(width=1000, height=1000),
+            image=logo_image_data | {"width": 1000, "height": 1000},
             source_type=LogoSourceType.LOGO,
         )
     )

--- a/tests/sync_jobs_scraped_pipelines/broken_encoding_filter/test_broken_encoding_filter.py
+++ b/tests/sync_jobs_scraped_pipelines/broken_encoding_filter/test_broken_encoding_filter.py
@@ -18,7 +18,7 @@ assert len(fixtures_raising) > 0, "No fixtures found"
 @pytest.mark.asyncio
 async def test_broken_encoding_filter_raising(description_html: str):
     with pytest.raises(DropItem):
-        await process(dict(description_html=description_html))
+        await process({"description_html": description_html})
 
 
 fixtures_passing = [
@@ -32,4 +32,4 @@ assert len(fixtures_passing) > 0, "No fixtures found"
 @pytest.mark.parametrize("description_html", fixtures_passing)
 @pytest.mark.asyncio
 async def test_broken_encoding_filter_passing(description_html: str):
-    await process(dict(description_html=description_html))
+    await process({"description_html": description_html})

--- a/tests/sync_jobs_scraped_pipelines/test_blocklist_filter.py
+++ b/tests/sync_jobs_scraped_pipelines/test_blocklist_filter.py
@@ -6,23 +6,23 @@ from jg.coop.sync.jobs_scraped.pipelines.blocklist_filter import process
 
 @pytest.mark.asyncio
 async def test_blocklist_filter_lets_junior_through():
-    await process(dict(title="Junior Python Developer"))
+    await process({"title": "Junior Python Developer"})
 
 
 @pytest.mark.asyncio
 async def test_blocklist_filter_lets_junior_senior_through():
-    await process(dict(title="Python Developer, Junior/Senior"))
+    await process({"title": "Python Developer, Junior/Senior"})
 
 
 @pytest.mark.asyncio
 async def test_blocklist_filter_lets_senior_junior_through():
-    await process(dict(title="Python Developer, Senior/Junior"))
+    await process({"title": "Python Developer, Senior/Junior"})
 
 
 @pytest.mark.asyncio
 async def test_blocklist_filter_blocks_senior():
     with pytest.raises(DropItem):
-        await process(dict(title="Senior Python Developer"))
+        await process({"title": "Senior Python Developer"})
 
 
 @pytest.mark.parametrize(
@@ -39,4 +39,4 @@ async def test_blocklist_filter_blocks_senior():
 @pytest.mark.asyncio
 async def test_blocklist_filter_drops_machine_programmers(title):
     with pytest.raises(DropItem):
-        await process(dict(title=title))
+        await process({"title": title})

--- a/tests/sync_jobs_scraped_pipelines/test_canonical_url.py
+++ b/tests/sync_jobs_scraped_pipelines/test_canonical_url.py
@@ -7,68 +7,70 @@ from jg.coop.sync.jobs_scraped.pipelines.canonical_url import process
     "item, expected",
     [
         pytest.param(
-            dict(
-                url="https://www.startupjobs.cz/nabidka/48407/venture-capital-analyst-associate"
-            ),
-            dict(
-                canonical_ids=["startupjobs#48407/venture-capital-analyst-associate"],
-                url="https://www.startupjobs.cz/nabidka/48407/venture-capital-analyst-associate",
-                source_urls=[
+            {
+                "url": "https://www.startupjobs.cz/nabidka/48407/venture-capital-analyst-associate"
+            },
+            {
+                "canonical_ids": [
+                    "startupjobs#48407/venture-capital-analyst-associate"
+                ],
+                "url": "https://www.startupjobs.cz/nabidka/48407/venture-capital-analyst-associate",
+                "source_urls": [
                     "https://www.startupjobs.cz/nabidka/48407/venture-capital-analyst-associate"
                 ],
-            ),
+            },
             id="single URL",
         ),
         pytest.param(
-            dict(
-                url="https://www.startupjobs.cz/nabidka/97145/backend-engineer?utm_source=juniorguru&utm_medium=cpc&utm_campaign=juniorguru"
-            ),
-            dict(
-                canonical_ids=["startupjobs#97145/backend-engineer"],
-                url="https://www.startupjobs.cz/nabidka/97145/backend-engineer",
-                source_urls=[
+            {
+                "url": "https://www.startupjobs.cz/nabidka/97145/backend-engineer?utm_source=juniorguru&utm_medium=cpc&utm_campaign=juniorguru"
+            },
+            {
+                "canonical_ids": ["startupjobs#97145/backend-engineer"],
+                "url": "https://www.startupjobs.cz/nabidka/97145/backend-engineer",
+                "source_urls": [
                     "https://www.startupjobs.cz/nabidka/97145/backend-engineer?utm_source=juniorguru&utm_medium=cpc&utm_campaign=juniorguru"
                 ],
-            ),
+            },
             id="UTM params",
         ),
         pytest.param(
-            dict(
-                url="https://www.linkedin.com/jobs/view/4334211481",
-                apply_url="https://mafra.jobs.cz/detail-pozice?r=detail&id=2000805294",
-                source_urls=[
+            {
+                "url": "https://www.linkedin.com/jobs/view/4334211481",
+                "apply_url": "https://mafra.jobs.cz/detail-pozice?r=detail&id=2000805294",
+                "source_urls": [
                     "https://www.linkedin.com/jobs/search?keywords=junior%20programator&location=Czechia&geoId=104508036&f_TPR=r86400&position=1&pageNum=0"
                 ],
-            ),
-            dict(
-                canonical_ids=["jobscz#2000805294", "linkedin#4334211481"],
-                url="https://www.jobs.cz/rpd/2000805294/",
-                apply_url="https://mafra.jobs.cz/detail-pozice?r=detail&id=2000805294",
-                source_urls=[
+            },
+            {
+                "canonical_ids": ["jobscz#2000805294", "linkedin#4334211481"],
+                "url": "https://www.jobs.cz/rpd/2000805294/",
+                "apply_url": "https://mafra.jobs.cz/detail-pozice?r=detail&id=2000805294",
+                "source_urls": [
                     "https://www.linkedin.com/jobs/search?keywords=junior%20programator&location=Czechia&geoId=104508036&f_TPR=r86400&position=1&pageNum=0",
                     "https://www.linkedin.com/jobs/view/4334211481",
                 ],
-            ),
+            },
             id="multiple source URLs and IDs",
         ),
         pytest.param(
-            dict(
-                url="https://www.linkedin.com/jobs/view/4334211481",
-                apply_url="https://mafra.jobs.cz/detail-pozice?r=detail&id=2000805294",
-                source_urls=[
+            {
+                "url": "https://www.linkedin.com/jobs/view/4334211481",
+                "apply_url": "https://mafra.jobs.cz/detail-pozice?r=detail&id=2000805294",
+                "source_urls": [
                     "https://www.linkedin.com/jobs/search?keywords=junior%20programator&location=Czechia&geoId=104508036&f_TPR=r86400&position=1&pageNum=0",
                     "https://www.linkedin.com/jobs/view/4334211481",
                 ],
-            ),
-            dict(
-                canonical_ids=["jobscz#2000805294", "linkedin#4334211481"],
-                url="https://www.jobs.cz/rpd/2000805294/",
-                apply_url="https://mafra.jobs.cz/detail-pozice?r=detail&id=2000805294",
-                source_urls=[
+            },
+            {
+                "canonical_ids": ["jobscz#2000805294", "linkedin#4334211481"],
+                "url": "https://www.jobs.cz/rpd/2000805294/",
+                "apply_url": "https://mafra.jobs.cz/detail-pozice?r=detail&id=2000805294",
+                "source_urls": [
                     "https://www.linkedin.com/jobs/search?keywords=junior%20programator&location=Czechia&geoId=104508036&f_TPR=r86400&position=1&pageNum=0",
                     "https://www.linkedin.com/jobs/view/4334211481",
                 ],
-            ),
+            },
             id="deduplicate source URLs",
         ),
     ],

--- a/tests/sync_jobs_scraped_pipelines/test_employment_types_cleaner.py
+++ b/tests/sync_jobs_scraped_pipelines/test_employment_types_cleaner.py
@@ -56,24 +56,24 @@ def test_clean_employment_type_raises():
     "item, expected",
     [
         (
-            dict(employment_types=["Full-Time"]),
-            dict(employment_types=["fulltime"]),
+            {"employment_types": ["Full-Time"]},
+            {"employment_types": ["fulltime"]},
         ),
         (
-            dict(employment_types=["part time", "Full-Time"]),
-            dict(employment_types=["fulltime", "parttime"]),
+            {"employment_types": ["part time", "Full-Time"]},
+            {"employment_types": ["fulltime", "parttime"]},
         ),
         (
-            dict(employment_types=["other", "Full-Time"]),
-            dict(employment_types=["fulltime"]),
+            {"employment_types": ["other", "Full-Time"]},
+            {"employment_types": ["fulltime"]},
         ),
         (
-            dict(employment_types=["other"]),
-            dict(employment_types=[]),
+            {"employment_types": ["other"]},
+            {"employment_types": []},
         ),
         (
-            dict(),
-            dict(),
+            {},
+            {},
         ),
     ],
 )

--- a/tests/sync_jobs_scraped_pipelines/test_gender_remover.py
+++ b/tests/sync_jobs_scraped_pipelines/test_gender_remover.py
@@ -74,7 +74,7 @@ from jg.coop.sync.jobs_scraped.pipelines.gender_remover import process
 )
 @pytest.mark.asyncio
 async def test_gender_remover_german(title, expected):
-    item = await process(dict(title=title))
+    item = await process({"title": title})
 
     assert item["title"] == expected
 
@@ -90,7 +90,7 @@ async def test_gender_remover_german(title, expected):
 )
 @pytest.mark.asyncio
 async def test_gender_remover_french(title, expected):
-    item = await process(dict(title=title))
+    item = await process({"title": title})
 
     assert item["title"] == expected
 
@@ -114,7 +114,7 @@ async def test_gender_remover_french(title, expected):
 )
 @pytest.mark.asyncio
 async def test_gender_remover_czech(title, expected):
-    item = await process(dict(title=title))
+    item = await process({"title": title})
 
     assert item["title"] == expected
 
@@ -127,6 +127,6 @@ async def test_gender_remover_czech(title, expected):
 )
 @pytest.mark.asyncio
 async def test_gender_remover_false_positives(title):
-    item = await process(dict(title=title))
+    item = await process({"title": title})
 
     assert item["title"] == title

--- a/tests/sync_jobs_scraped_pipelines/test_language_filter.py
+++ b/tests/sync_jobs_scraped_pipelines/test_language_filter.py
@@ -7,11 +7,11 @@ from jg.coop.sync.jobs_scraped.pipelines.language_filter import process
 @pytest.mark.parametrize("lang", ["cs", "en", "sk"])
 @pytest.mark.asyncio
 async def test_language_filter_lets_relevant_languages_through(lang: str):
-    await process(dict(lang=lang))
+    await process({"lang": lang})
 
 
 @pytest.mark.parametrize("lang", ["es", "de", "fr"])
 @pytest.mark.asyncio
 async def test_language_filter_drops_irrelevant_languages(lang: str):
     with pytest.raises(DropItem):
-        await process(dict(lang=lang))
+        await process({"lang": lang})

--- a/tests/sync_jobs_scraped_pipelines/test_language_parser.py
+++ b/tests/sync_jobs_scraped_pipelines/test_language_parser.py
@@ -27,10 +27,10 @@ async def test_language_parser_process():
         socjalno-motywacyjny, w tym prywatną opiekę zdrowotną i Pracowniczy Program Emerytalny,</li>
         <li> konkurencyjne wynagrodzenie,</li><li> pakiet benefitów,</li><li> profesjonalny system...
     """
-    item = dict(
-        title="Junior Software Engineer",
-        description_text=extract_text(description_text),
-    )
+    item = {
+        "title": "Junior Software Engineer",
+        "description_text": extract_text(description_text),
+    }
     item = await process(item)
 
     assert item["lang"] == "pl"
@@ -38,10 +38,10 @@ async def test_language_parser_process():
 
 @pytest.mark.asyncio
 async def test_language_parser_process_missing_body_does_not_raise():
-    item = dict(
-        title="Junior Software Engineer",
-        description_text="-",
-    )
+    item = {
+        "title": "Junior Software Engineer",
+        "description_text": "-",
+    }
     item = await process(item)
 
     assert len(item["lang"]) == 2

--- a/tests/sync_jobs_scraped_pipelines/test_utm_params.py
+++ b/tests/sync_jobs_scraped_pipelines/test_utm_params.py
@@ -7,48 +7,48 @@ from jg.coop.sync.jobs_scraped.pipelines.utm_params import process
     "item, expected",
     [
         pytest.param(
-            dict(
-                url="https://www.startupjobs.cz/nabidka/97145/backend-engineer",
-            ),
+            {
+                "url": "https://www.startupjobs.cz/nabidka/97145/backend-engineer",
+            },
             "https://www.startupjobs.cz/nabidka/97145/backend-engineer?utm_source=juniorguru",
             id="No UTM params",
         ),
         pytest.param(
-            dict(
-                url="https://www.startupjobs.cz/nabidka/97145/backend-engineer",
-                source_urls=[
+            {
+                "url": "https://www.startupjobs.cz/nabidka/97145/backend-engineer",
+                "source_urls": [
                     "https://example.com/?utm_source=linkedin&utm_medium=cpc&utm_campaign=linkedin"
                 ],
-            ),
+            },
             "https://www.startupjobs.cz/nabidka/97145/backend-engineer?utm_campaign=linkedin&utm_medium=cpc&utm_source=juniorguru",
             id="Source URL contains params, source changes to JG",
         ),
         pytest.param(
-            dict(
-                url="https://www.startupjobs.cz/nabidka/97145/backend-engineer",
-                apply_url="https://example.com/?utm_source=linkedin&utm_medium=cpc&utm_campaign=linkedin",
-            ),
+            {
+                "url": "https://www.startupjobs.cz/nabidka/97145/backend-engineer",
+                "apply_url": "https://example.com/?utm_source=linkedin&utm_medium=cpc&utm_campaign=linkedin",
+            },
             "https://www.startupjobs.cz/nabidka/97145/backend-engineer?utm_campaign=linkedin&utm_medium=cpc&utm_source=juniorguru",
             id="Apply URL contains params, source changes to JG",
         ),
         pytest.param(
-            dict(
-                url="https://www.startupjobs.cz/nabidka/97145/backend-engineer",
-                apply_url="https://example.com/?utm_source=juniorguru&utm_medium=cpc&utm_campaign=linkedin",
-                source_urls=[
+            {
+                "url": "https://www.startupjobs.cz/nabidka/97145/backend-engineer",
+                "apply_url": "https://example.com/?utm_source=juniorguru&utm_medium=cpc&utm_campaign=linkedin",
+                "source_urls": [
                     "https://example.com/?utm_source=juniorguru&utm_medium=web&utm_campaign=linkedin"
                 ],
-            ),
+            },
             "https://www.startupjobs.cz/nabidka/97145/backend-engineer?utm_campaign=linkedin&utm_source=juniorguru",
             id="URLs contain conflicting params, source changes to JG, drop others if differing",
         ),
         pytest.param(
-            dict(
-                url="https://example.com/?something=12345",
-                source_urls=[
+            {
+                "url": "https://example.com/?something=12345",
+                "source_urls": [
                     "https://example.com/?utm_source=linkedin&utm_medium=cpc&utm_campaign=linkedin"
                 ],
-            ),
+            },
             "https://example.com/?something=12345&utm_campaign=linkedin&utm_medium=cpc&utm_source=juniorguru",
             id="Other params in URL are preserved",
         ),

--- a/tests/test_cli_data.py
+++ b/tests/test_cli_data.py
@@ -43,12 +43,16 @@ def test_make_schema_idempotent_raises():
 @pytest.mark.parametrize(
     "row_from, row_to, expected",
     [
-        (dict(), dict(), dict()),
-        (dict(a=1, b=2, c=3), dict(a=1, b=2, c=3), dict()),
-        (dict(a=None, b=None, c=3), dict(a=None, b=None, c=3), dict()),
-        (dict(a=1, b=2, c=3), dict(a=1, b=None, c=3), dict(b=2)),
-        (dict(a=None, b=None, c=3), dict(a=1, b=2, c=3), dict()),
-        (dict(a=None, b=42, c=3, d=None), dict(a=1, b=None, c=3, d=None), dict(b=42)),
+        ({}, {}, {}),
+        ({"a": 1, "b": 2, "c": 3}, {"a": 1, "b": 2, "c": 3}, {}),
+        ({"a": None, "b": None, "c": 3}, {"a": None, "b": None, "c": 3}, {}),
+        ({"a": 1, "b": 2, "c": 3}, {"a": 1, "b": None, "c": 3}, {"b": 2}),
+        ({"a": None, "b": None, "c": 3}, {"a": 1, "b": 2, "c": 3}, {}),
+        (
+            {"a": None, "b": 42, "c": 3, "d": None},
+            {"a": 1, "b": None, "c": 3, "d": None},
+            {"b": 42},
+        ),
     ],
 )
 def test_get_row_updates(row_from, row_to, expected):
@@ -58,7 +62,7 @@ def test_get_row_updates(row_from, row_to, expected):
 @pytest.mark.parametrize(
     "row_from, row_to",
     [
-        (dict(a=1, b=2, c=3), dict(a=1, b=42, c=3)),
+        ({"a": 1, "b": 2, "c": 3}, {"a": 1, "b": 42, "c": 3}),
     ],
 )
 def test_get_row_updates_raises_conflict(row_from, row_to):
@@ -69,8 +73,8 @@ def test_get_row_updates_raises_conflict(row_from, row_to):
 @pytest.mark.parametrize(
     "row_from, row_to",
     [
-        (dict(a=1, b=2, c=3, d=4), dict(a=1, b=2, c=3)),
-        (dict(a=1, b=2, c=3), dict(a=1, b=2, c=3, d=4)),
+        ({"a": 1, "b": 2, "c": 3, "d": 4}, {"a": 1, "b": 2, "c": 3}),
+        ({"a": 1, "b": 2, "c": 3}, {"a": 1, "b": 2, "c": 3, "d": 4}),
     ],
 )
 def test_get_row_updates_raises_inconsistence(row_from, row_to):

--- a/tests/test_models_base.py
+++ b/tests/test_models_base.py
@@ -26,11 +26,11 @@ def test_json_dumps(o, expected):
 
 
 def test_json_dumps_item():
-    item = dict(
-        posted_at=datetime(2020, 4, 30, 14, 35, 10),
-        title="Junior developer",
-        employment_types=frozenset(["full-time"]),
-    )
+    item = {
+        "posted_at": datetime(2020, 4, 30, 14, 35, 10),
+        "title": "Junior developer",
+        "employment_types": frozenset(["full-time"]),
+    }
 
     assert json_dumps(item) == (
         "{"

--- a/tests/test_models_club.py
+++ b/tests/test_models_club.py
@@ -155,14 +155,14 @@ def test_message_digest_channels(test_db):
 
 def test_message_digest_channels_ignores_private_messages(test_db):
     user = create_user(1)
-    kwargs = dict(
-        created_at=datetime(2023, 5, 2),
-        content="abcd",
-        channel_id=1,
-        channel_name="channel",
-        parent_channel_id=100,
-        parent_channel_name="parent-channel",
-    )
+    kwargs = {
+        "created_at": datetime(2023, 5, 2),
+        "content": "abcd",
+        "channel_id": 1,
+        "channel_name": "channel",
+        "parent_channel_id": 100,
+        "parent_channel_name": "parent-channel",
+    }
     for i in range(3):
         create_message(10 + i, user, is_private=False, **kwargs)
     for i in range(10):
@@ -219,13 +219,13 @@ def test_message_digest_channels_ignores_certain_channels(test_db):
 
 def test_message_digest_channels_ignores_old_messages(test_db):
     user = create_user(1)
-    kwargs = dict(
-        content="abcd",
-        channel_id=1,
-        channel_name="channel",
-        parent_channel_id=100,
-        parent_channel_name="parent-channel",
-    )
+    kwargs = {
+        "content": "abcd",
+        "channel_id": 1,
+        "channel_name": "channel",
+        "parent_channel_id": 100,
+        "parent_channel_name": "parent-channel",
+    }
     for i in range(3):
         create_message(10 + i, user, created_at=datetime(2023, 4, 29), **kwargs)
     for i in range(10):

--- a/tests/test_models_course_provider.py
+++ b/tests/test_models_course_provider.py
@@ -1,4 +1,4 @@
-from typing import Generator
+from collections.abc import Generator
 
 import pytest
 

--- a/tests/test_models_partner.py
+++ b/tests/test_models_partner.py
@@ -1,4 +1,4 @@
-from typing import Generator
+from collections.abc import Generator
 
 import pytest
 

--- a/tests/test_models_podcast.py
+++ b/tests/test_models_podcast.py
@@ -18,11 +18,11 @@ def test_publish_at_prg():
 @pytest.mark.parametrize(
     "kwargs, expected",
     [
-        (dict(), "Adéla (Company) about testing"),
-        (dict(number=True, affiliation=True), "#1 Adéla (Company) about testing"),
-        (dict(number=False, affiliation=True), "Adéla (Company) about testing"),
-        (dict(number=True, affiliation=False), "#1 Adéla about testing"),
-        (dict(number=False, affiliation=False), "Adéla about testing"),
+        ({}, "Adéla (Company) about testing"),
+        ({"number": True, "affiliation": True}, "#1 Adéla (Company) about testing"),
+        ({"number": False, "affiliation": True}, "Adéla (Company) about testing"),
+        ({"number": True, "affiliation": False}, "#1 Adéla about testing"),
+        ({"number": False, "affiliation": False}, "Adéla about testing"),
     ],
 )
 def test_format_title(kwargs, expected):
@@ -36,11 +36,11 @@ def test_format_title(kwargs, expected):
 @pytest.mark.parametrize(
     "kwargs, expected",
     [
-        (dict(), "Adéla about testing"),
-        (dict(number=True, affiliation=True), "#1 Adéla about testing"),
-        (dict(number=False, affiliation=True), "Adéla about testing"),
-        (dict(number=True, affiliation=False), "#1 Adéla about testing"),
-        (dict(number=False, affiliation=False), "Adéla about testing"),
+        ({}, "Adéla about testing"),
+        ({"number": True, "affiliation": True}, "#1 Adéla about testing"),
+        ({"number": False, "affiliation": True}, "Adéla about testing"),
+        ({"number": True, "affiliation": False}, "#1 Adéla about testing"),
+        ({"number": False, "affiliation": False}, "Adéla about testing"),
     ],
 )
 def test_format_title_with_no_affiliation(kwargs, expected):
@@ -54,11 +54,11 @@ def test_format_title_with_no_affiliation(kwargs, expected):
 @pytest.mark.parametrize(
     "kwargs, expected",
     [
-        (dict(), "About testing"),
-        (dict(number=True, affiliation=True), "#1 About testing"),
-        (dict(number=False, affiliation=True), "About testing"),
-        (dict(number=True, affiliation=False), "#1 About testing"),
-        (dict(number=False, affiliation=False), "About testing"),
+        ({}, "About testing"),
+        ({"number": True, "affiliation": True}, "#1 About testing"),
+        ({"number": False, "affiliation": True}, "About testing"),
+        ({"number": True, "affiliation": False}, "#1 About testing"),
+        ({"number": False, "affiliation": False}, "About testing"),
     ],
 )
 def test_format_title_with_no_guest(kwargs, expected):

--- a/tests/test_models_role.py
+++ b/tests/test_models_role.py
@@ -1,4 +1,4 @@
-from typing import Generator
+from collections.abc import Generator
 
 import pytest
 

--- a/tests/test_models_sponsor.py
+++ b/tests/test_models_sponsor.py
@@ -1,5 +1,5 @@
+from collections.abc import Generator
 from datetime import date
-from typing import Generator
 
 import pytest
 

--- a/tests/test_models_stage.py
+++ b/tests/test_models_stage.py
@@ -1,6 +1,6 @@
 import random
 import uuid
-from typing import Generator
+from collections.abc import Generator
 
 import pytest
 

--- a/tests/test_models_sync.py
+++ b/tests/test_models_sync.py
@@ -56,7 +56,7 @@ def test_times_min(test_db):
     sync.command_start("cows", 15 * NS_IN_MIN)
     sync.command_end("cows", 30 * NS_IN_MIN)
 
-    assert sync.times_min() == dict(cows=15, cats=10, dogs=5)
+    assert sync.times_min() == {"cows": 15, "cats": 10, "dogs": 5}
 
 
 @pytest.mark.parametrize(

--- a/tests/test_models_topic.py
+++ b/tests/test_models_topic.py
@@ -1,4 +1,4 @@
-from typing import Generator
+from collections.abc import Generator
 
 import pytest
 

--- a/tests/test_sync_digest.py
+++ b/tests/test_sync_digest.py
@@ -31,13 +31,13 @@ def test_format_message():
 
 
 def test_format_channel_digest():
-    channel_digest = dict(
-        channel_id=123,
-        channel_name="general",
-        parent_channel_id=123,
-        parent_channel_name="general",
-        size=4,
-    )
+    channel_digest = {
+        "channel_id": 123,
+        "channel_name": "general",
+        "parent_channel_id": 123,
+        "parent_channel_name": "general",
+        "size": 4,
+    }
 
     assert format_channel_digest(channel_digest) == (
         "**#general**\n"

--- a/tests/test_sync_organizations.py
+++ b/tests/test_sync_organizations.py
@@ -167,9 +167,27 @@ def test_prepare_tiers():
     ]
 
     assert prepare_tiers(plans) == [
-        dict(priority=0, plan_id=111, name="Prdíme", price=1, member_price=None),
-        dict(priority=1, plan_id=222, name="Smrdíme", price=2, member_price=2),
-        dict(priority=2, plan_id=333, name="Voníme", price=3, member_price=3),
+        {
+            "priority": 0,
+            "plan_id": 111,
+            "name": "Prdíme",
+            "price": 1,
+            "member_price": None,
+        },
+        {
+            "priority": 1,
+            "plan_id": 222,
+            "name": "Smrdíme",
+            "price": 2,
+            "member_price": 2,
+        },
+        {
+            "priority": 2,
+            "plan_id": 333,
+            "name": "Voníme",
+            "price": 3,
+            "member_price": 3,
+        },
     ]
 
 
@@ -198,35 +216,35 @@ def test_prepare_tiers_with_extras():
         ),
     ]
     extras = {
-        "Smrdíme": dict(max_sponsors=4, courses_highlight=True),
-        "Prdíme": dict(courses_highlight=True),
+        "Smrdíme": {"max_sponsors": 4, "courses_highlight": True},
+        "Prdíme": {"courses_highlight": True},
     }
 
     assert prepare_tiers(plans, extras=extras) == [
-        dict(
-            priority=0,
-            plan_id=111,
-            name="Prdíme",
-            price=1,
-            member_price=None,
-            courses_highlight=True,
-        ),
-        dict(
-            priority=1,
-            plan_id=222,
-            name="Smrdíme",
-            price=2,
-            member_price=2,
-            max_sponsors=4,
-            courses_highlight=True,
-        ),
-        dict(
-            priority=2,
-            plan_id=333,
-            name="Voníme",
-            price=3,
-            member_price=3,
-        ),
+        {
+            "priority": 0,
+            "plan_id": 111,
+            "name": "Prdíme",
+            "price": 1,
+            "member_price": None,
+            "courses_highlight": True,
+        },
+        {
+            "priority": 1,
+            "plan_id": 222,
+            "name": "Smrdíme",
+            "price": 2,
+            "member_price": 2,
+            "max_sponsors": 4,
+            "courses_highlight": True,
+        },
+        {
+            "priority": 2,
+            "plan_id": 333,
+            "name": "Voníme",
+            "price": 3,
+            "member_price": 3,
+        },
     ]
 
 
@@ -249,7 +267,13 @@ def test_prepare_tiers_ignores_individual_plans():
     ]
 
     assert prepare_tiers(plans) == [
-        dict(priority=0, plan_id=333, name="Voníme", price=3, member_price=3),
+        {
+            "priority": 0,
+            "plan_id": 333,
+            "name": "Voníme",
+            "price": 3,
+            "member_price": 3,
+        },
     ]
 
 
@@ -272,5 +296,11 @@ def test_prepare_tiers_ignores_private_plans():
     ]
 
     assert prepare_tiers(plans) == [
-        dict(priority=0, plan_id=333, name="Voníme", price=3, member_price=3),
+        {
+            "priority": 0,
+            "plan_id": 333,
+            "name": "Voníme",
+            "price": 3,
+            "member_price": 3,
+        },
     ]

--- a/tests/test_sync_pages.py
+++ b/tests/test_sync_pages.py
@@ -19,11 +19,11 @@ def test_parse_meta():
 
                 """
         )
-    ) == dict(
-        title="Jak na Git a GitHub",
-        description="Co je Git a k čemu se používá? Jaký je rozdíl mezi Gitem a GitHubem? Jak začít s Gitem?",
-        template="main_handbook.html",
-    )
+    ) == {
+        "title": "Jak na Git a GitHub",
+        "description": "Co je Git a k čemu se používá? Jaký je rozdíl mezi Gitem a GitHubem? Jak začít s Gitem?",
+        "template": "main_handbook.html",
+    }
 
 
 def test_parse_notes():

--- a/tests/testing_utils.py
+++ b/tests/testing_utils.py
@@ -1,7 +1,8 @@
 import random
+from collections.abc import Generator
 from datetime import date, datetime, timedelta
 from pathlib import Path
-from typing import Any, Generator
+from typing import Any
 
 import pytest
 from peewee import SqliteDatabase
@@ -67,59 +68,61 @@ def param_xfail_missing(path, values=2):
 
 
 def prepare_user_data(id_: int, **kwargs) -> dict[str, Any]:
-    return dict(
-        id=id_,
-        is_member=kwargs.get("is_member", True),
-        is_bot=kwargs.get("is_bot", False),
-        avatar_path=kwargs.get("avatar_path"),
-        display_name=kwargs.get("display_name", "Kuře Žluté"),
-        mention=kwargs.get("mention", f"<@{id_}>"),
-        joined_at=kwargs.get("joined_at", datetime.now() - timedelta(days=3)),
-        expires_at=kwargs.get("expires_at", datetime.now() + timedelta(days=100)),
-        initial_roles=kwargs.get("initial_roles", []),
-    )
+    return {
+        "id": id_,
+        "is_member": kwargs.get("is_member", True),
+        "is_bot": kwargs.get("is_bot", False),
+        "avatar_path": kwargs.get("avatar_path"),
+        "display_name": kwargs.get("display_name", "Kuře Žluté"),
+        "mention": kwargs.get("mention", f"<@{id_}>"),
+        "joined_at": kwargs.get("joined_at", datetime.now() - timedelta(days=3)),
+        "expires_at": kwargs.get("expires_at", datetime.now() + timedelta(days=100)),
+        "initial_roles": kwargs.get("initial_roles", []),
+    }
 
 
 def prepare_job_data(id_: int | str, **kwargs) -> dict[str, Any]:
-    return dict(
-        id=str(id_),
-        posted_at=kwargs.get("posted_at", date(2019, 7, 6)),
-        company_name=kwargs.get("company_name", "Honza Ltd."),
-        employment_types=kwargs.get("employment_types", ["internship"]),
-        title=kwargs.get("title", "Junior Software Engineer"),
-        company_url=kwargs.get("company_url", "https://example.com"),
-        email=kwargs.get("email", "recruiter@example.com"),
-        remote=kwargs.get("remote", False),
-        locations_raw=kwargs.get("locations_raw", ["Brno, Czech Republic"]),
-        locations=kwargs.get("locations", [{"name": "Brno", "region": "Brno"}]),
-        description_html=kwargs.get(
+    return {
+        "id": str(id_),
+        "posted_at": kwargs.get("posted_at", date(2019, 7, 6)),
+        "company_name": kwargs.get("company_name", "Honza Ltd."),
+        "employment_types": kwargs.get("employment_types", ["internship"]),
+        "title": kwargs.get("title", "Junior Software Engineer"),
+        "company_url": kwargs.get("company_url", "https://example.com"),
+        "email": kwargs.get("email", "recruiter@example.com"),
+        "remote": kwargs.get("remote", False),
+        "locations_raw": kwargs.get("locations_raw", ["Brno, Czech Republic"]),
+        "locations": kwargs.get("locations", [{"name": "Brno", "region": "Brno"}]),
+        "description_html": kwargs.get(
             "description", "<p><strong>Useful</strong> description.</p>"
         ),
-        source=kwargs.get("source", random.choice(["juniorguru", "moo", "boo", "foo"])),
-        expires_at=kwargs.get("expires_at", date.today() + timedelta(days=3)),
-        junior_rank=kwargs.get("junior_rank", 10),
-        sort_rank=kwargs.get("sort_rank", 5),
-        lang=kwargs.get("lang", "en"),
-        link=kwargs.get("link", "https://example.com/jobs/123/"),
-        apply_link=kwargs.get("apply_link"),
-        pricing_plan=kwargs.get("pricing_plan", "community"),
-    )
+        "source": kwargs.get(
+            "source", random.choice(["juniorguru", "moo", "boo", "foo"])
+        ),
+        "expires_at": kwargs.get("expires_at", date.today() + timedelta(days=3)),
+        "junior_rank": kwargs.get("junior_rank", 10),
+        "sort_rank": kwargs.get("sort_rank", 5),
+        "lang": kwargs.get("lang", "en"),
+        "link": kwargs.get("link", "https://example.com/jobs/123/"),
+        "apply_link": kwargs.get("apply_link"),
+        "pricing_plan": kwargs.get("pricing_plan", "community"),
+    }
 
 
 def prepare_logo_data(id_: int, **kwargs) -> dict[str, Any]:
     today = date.today()
-    return dict(
-        id=id_,
-        name=kwargs.get("name", "Awesome Company"),
-        filename=kwargs.get("filename", "awesome-company.svg"),
-        email=kwargs.get("email", "recruitment@example.com"),
-        email_reports=kwargs.get("email_reports", True),
-        link=kwargs.get("link", "https://jobs.example.com"),
-        link_re=kwargs.get("link_re"),
-        months=kwargs.get("monhts", 12),
-        starts_at=kwargs.get("starts_at", today),
-        expires_at=kwargs.get("expires_at", today + timedelta(days=365)),
-    )
+    return {
+        "id": id_,
+        "name": kwargs.get("name", "Awesome Company"),
+        "filename": kwargs.get("filename", "awesome-company.svg"),
+        "email": kwargs.get("email", "recruitment@example.com"),
+        "email_reports": kwargs.get("email_reports", True),
+        "link": kwargs.get("link", "https://jobs.example.com"),
+        "link_re": kwargs.get("link_re"),
+        "months": kwargs.get("monhts", 12),
+        "starts_at": kwargs.get("starts_at", today),
+        "expires_at": kwargs.get("expires_at", today + timedelta(days=365)),
+    }
 
 
 def prepare_organization_data(slug: str, **kwargs) -> dict[str, Any]:


### PR DESCRIPTION
### Motivation

- Modernize type imports by using `collections.abc` protocol types to match runtime typing and reduce reliance on `typing` where unnecessary.
- Normalize code style to prefer literal mappings and sequences (`{...}` / `[...]`) instead of `dict(...)`/`list(...)` for readability and consistent serialization.
- Align linting configuration to catch related patterns by adding new rules to Ruff.

### Description

- Replaced many `from typing import ...` usages with `from collections.abc import ...` across CLI, lib, models, sync and web modules and tests, updating annotations and uses accordingly.
- Converted numerous `dict(...)` constructions to literal `{...}` (and similar list/tuple usages where present) for consistent style and deterministic ordering in serialized outputs.
- Minor related cleanups such as changing `retry_defaults` to a dict literal and small dict/return formatting changes in multiple sync and generator functions.
- Updated `pyproject.toml` to extend `ruff` `select` with `C408` and `UP035`.

### Testing

- Ran the test suite with `pytest` (project `pytest` configuration is used) on the modified codebase.
- All automated tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a731a879d0083249cff2ed194a6581b)