### PR TITLE
Enable Ruff UP043 and drop redundant default type arguments

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,7 +88,7 @@ asyncio_default_fixture_loop_scope = "function"
 target-version = "py313"
 
 [tool.ruff.lint]
-select = ["C408", "E4", "E7", "E9", "F", "FURB167", "I"]
+select = ["C408", "E4", "E7", "E9", "F", "FURB167", "I", "UP043"]
 
 [tool.ruff.lint.isort]
 combine-as-imports = true

--- a/src/jg/coop/lib/buttondown.py
+++ b/src/jg/coop/lib/buttondown.py
@@ -98,7 +98,7 @@ class ButtondownAPI:
                 metadata=exc_data.get("metadata"),
             ) from e
 
-    async def get_emails_before(self, before_date: date) -> AsyncGenerator[dict, None]:
+    async def get_emails_before(self, before_date: date) -> AsyncGenerator[dict]:
         next_url = f"emails?publish_date__end={before_date}"
         while next_url:
             logger.debug(f"Fetching emails: {next_url}")
@@ -119,7 +119,7 @@ class ButtondownAPI:
             params={"status": "draft", "creation_date__start": since_date.isoformat()},
         )
 
-    async def get_drafts(self) -> AsyncGenerator[dict, None]:
+    async def get_drafts(self) -> AsyncGenerator[dict]:
         next_url = "emails?status=draft"
         while next_url:
             logger.debug(f"Fetching drafts: {next_url}")

--- a/src/jg/coop/lib/charts.py
+++ b/src/jg/coop/lib/charts.py
@@ -45,7 +45,7 @@ def months(from_date: date, to_date: date) -> list[date]:
     return list(generate_months(from_date, to_date))
 
 
-def generate_months(from_date: date, to_date: date) -> Generator[date, None, None]:
+def generate_months(from_date: date, to_date: date) -> Generator[date]:
     d = from_date
     while d <= to_date:
         last_date_of_month = d.replace(day=calendar.monthrange(d.year, d.month)[1])

--- a/src/jg/coop/lib/cli.py
+++ b/src/jg/coop/lib/cli.py
@@ -23,7 +23,7 @@ def import_command(name: str, import_path: str) -> click.Command:
 
 def find_commands(
     package: str | ModuleType, flatten: list[str] | None = None
-) -> Generator[tuple[str, str], None, None]:
+) -> Generator[tuple[str, str]]:
     if isinstance(package, str):
         package = import_module(package)
     for _, module_name, _ in pkgutil.iter_modules(package.__path__):

--- a/src/jg/coop/lib/discord_club.py
+++ b/src/jg/coop/lib/discord_club.py
@@ -238,7 +238,7 @@ def is_message_over_period_ago(
 
 async def fetch_threads(
     channel: discord.abc.GuildChannel | discord.DMChannel,
-) -> AsyncGenerator[discord.Thread, None]:
+) -> AsyncGenerator[discord.Thread]:
     try:
         channel_threads = channel.threads
     except AttributeError:

--- a/src/jg/coop/lib/images.py
+++ b/src/jg/coop/lib/images.py
@@ -197,7 +197,7 @@ def _get_source_paths(metafile: dict[str, Any]) -> list[str]:
 
 def _get_fs_snapshot(
     paths: Iterable[str | Path],
-) -> Generator[tuple[str, tuple[float, int]], None, None]:
+) -> Generator[tuple[str, tuple[float, int]]]:
     for path in paths:
         try:
             stat = Path(path).stat()

--- a/src/jg/coop/lib/location.py
+++ b/src/jg/coop/lib/location.py
@@ -238,7 +238,7 @@ async def locate(
 
 def generate_queries(
     location_raw: str,
-) -> Generator[tuple[str, ResponseRegionType], None, None]:
+) -> Generator[tuple[str, ResponseRegionType]]:
     # rewrite strings not recognized by the API
     for rewrite_re, rewrite_value in REWRITES_RE.items():
         location_raw = rewrite_re.sub(rewrite_value, location_raw)

--- a/src/jg/coop/lib/loggers.py
+++ b/src/jg/coop/lib/loggers.py
@@ -46,9 +46,7 @@ class Logger(logging.Logger):
     def __getitem__(self, name) -> logging.Logger:
         return self.getChild(str(name))
 
-    def progress(
-        self, iterable: Iterable[T], chunk_size=100
-    ) -> Generator[T, None, None]:
+    def progress(self, iterable: Iterable[T], chunk_size=100) -> Generator[T]:
         total_count = 0
         for chunk in chunks(iterable, size=chunk_size):
             yield from chunk

--- a/src/jg/coop/lib/memberful.py
+++ b/src/jg/coop/lib/memberful.py
@@ -72,9 +72,7 @@ class MemberfulAPI:
         logger.debug("Sending a mutation")
         return self.client.execute(gql(mutation), variable_values=variable_values)
 
-    def get_nodes(
-        self, query: str, variable_values: dict = None
-    ) -> Generator[dict, None, None]:
+    def get_nodes(self, query: str, variable_values: dict = None) -> Generator[dict]:
         if match := COLLECTION_NAME_RE.search(query):
             collection_name = match.group("collection_name")
         else:

--- a/src/jg/coop/lib/mutations.py
+++ b/src/jg/coop/lib/mutations.py
@@ -126,7 +126,7 @@ class MutatingProxy:
 
 
 @contextmanager
-def mutating(*args, **kwargs) -> Generator[MutatingProxy, None, None]:
+def mutating(*args, **kwargs) -> Generator[MutatingProxy]:
     yield MutatingProxy(*args, **kwargs)
 
 

--- a/src/jg/coop/lib/template_filters.py
+++ b/src/jg/coop/lib/template_filters.py
@@ -172,13 +172,13 @@ def mapping(mapping: dict, keys: Iterable) -> list:
     return [mapping[key] for key in keys]
 
 
-def mainnav(nav: Navigation) -> Generator[dict, None, None]:
+def mainnav(nav: Navigation) -> Generator[dict]:
     for item in list(nav)[:6]:
         first_child = _get_first_child(item)
         yield {"title": item.title, "url": first_child.url, "is_active": item.active}
 
 
-def subnav(nav: Navigation) -> Generator[dict, None, None]:
+def subnav(nav: Navigation) -> Generator[dict]:
     mainnav_item = next(item for item in nav if item.active)
     for item in mainnav_item.children:
         first_child = _get_first_child(item)
@@ -196,7 +196,7 @@ def _get_first_child(item: StructureItem) -> StructureItem:
     return children[0]
 
 
-def toc(page: Page) -> Generator[dict, None, None]:
+def toc(page: Page) -> Generator[dict]:
     # for pages without children, this should result in the same
     # value as page.parent, but for pages further down the tree,
     # this ensures we display only the top-level items, regardless

--- a/src/jg/coop/sync/club_content/crawler.py
+++ b/src/jg/coop/sync/club_content/crawler.py
@@ -210,7 +210,7 @@ def get_channel_logger(
 async def fetch_messages(
     channel: GuildChannel | DMChannel,
     after: datetime | None,
-) -> AsyncGenerator[Message, None]:
+) -> AsyncGenerator[Message]:
     logger_m = logger["messages"][channel.id]
 
     # Get channel history iterator
@@ -230,7 +230,7 @@ async def fetch_messages(
 
 async def fetch_members_reacting_by_pin(
     reactions: list[Reaction],
-) -> AsyncGenerator[User | Member, None]:
+) -> AsyncGenerator[User | Member]:
     for reaction in reactions:
         if emoji_name(reaction.emoji) == ClubEmoji.PIN:
             async for user in reaction.users():

--- a/src/jg/coop/sync/newsletter/__init__.py
+++ b/src/jg/coop/sync/newsletter/__init__.py
@@ -339,7 +339,7 @@ async def delete_old_drafts(api: ButtondownAPI, max_drafts: int) -> None:
 
 def get_cv_review_types(
     tags: list[str],
-) -> Generator[Literal["cv", "gh", "li"], None, None]:
+) -> Generator[Literal["cv", "gh", "li"]]:
     prefix = "zpětná vazba na"
     relevant_tags = [tag for tag in map(str.lower, tags) if tag.startswith(prefix)]
     return [tag.removeprefix(prefix).strip() for tag in relevant_tags]

--- a/src/jg/coop/sync/newsletter/__init__.py
+++ b/src/jg/coop/sync/newsletter/__init__.py
@@ -4,7 +4,7 @@ from datetime import date
 from operator import itemgetter
 from pathlib import Path
 from pprint import pformat
-from typing import Generator, Literal
+from typing import Literal
 
 import click
 from jinja2 import Template
@@ -339,7 +339,7 @@ async def delete_old_drafts(api: ButtondownAPI, max_drafts: int) -> None:
 
 def get_cv_review_types(
     tags: list[str],
-) -> Generator[Literal["cv", "gh", "li"]]:
+) -> list[Literal["cv", "gh", "li"]]:
     prefix = "zpětná vazba na"
     relevant_tags = [tag for tag in map(str.lower, tags) if tag.startswith(prefix)]
     return [tag.removeprefix(prefix).strip() for tag in relevant_tags]

--- a/src/jg/coop/web/generators.py
+++ b/src/jg/coop/web/generators.py
@@ -57,7 +57,7 @@ class RedirectsConfig(YAMLConfig):
     registry: list[RedirectConfig]
 
 
-def generate_redirects() -> Generator[GeneratedDocument, None, None]:
+def generate_redirects() -> Generator[GeneratedDocument]:
     config = RedirectsConfig(**yaml.safe_load(REDIRECTS_YAML_PATH.read_text()))
     for redirect in config.registry:
         yield GeneratedDocument(
@@ -71,7 +71,7 @@ def generate_redirects() -> Generator[GeneratedDocument, None, None]:
         )
 
 
-def generate_region_jobs_pages() -> Generator[GeneratedDocument, None, None]:
+def generate_region_jobs_pages() -> Generator[GeneratedDocument]:
     jobs_file = Path("src/jg/coop/web/docs/jobs.jinja")
     jobs_text = jobs_file.read_text(encoding="utf-8-sig", errors="strict")
     content, meta = parse_document(jobs_text)
@@ -106,7 +106,7 @@ def generate_region_jobs_pages() -> Generator[GeneratedDocument, None, None]:
 
 
 @db.connection_context()
-def generate_job_pages() -> Generator[GeneratedDocument, None, None]:
+def generate_job_pages() -> Generator[GeneratedDocument]:
     for job in ListedJob.submitted_listing():
         yield GeneratedDocument(
             path=f"jobs/{job.submitted_job.id}.jinja",
@@ -127,7 +127,7 @@ def generate_job_pages() -> Generator[GeneratedDocument, None, None]:
 
 
 @db.connection_context()
-def generate_event_pages() -> Generator[GeneratedDocument, None, None]:
+def generate_event_pages() -> Generator[GeneratedDocument]:
     archive_size = Event.count_recording()
     for event in Event.listing():
         title_suffix = "online akce na Discordu junior.guru"
@@ -156,7 +156,7 @@ def generate_event_pages() -> Generator[GeneratedDocument, None, None]:
 
 
 @db.connection_context()
-def generate_podcast_episode_pages() -> Generator[GeneratedDocument, None, None]:
+def generate_podcast_episode_pages() -> Generator[GeneratedDocument]:
     for podcast_episode in PodcastEpisode.listing():
         yield GeneratedDocument(
             path=f"podcast/{podcast_episode.number}.jinja",
@@ -182,7 +182,7 @@ def generate_podcast_episode_pages() -> Generator[GeneratedDocument, None, None]
 
 
 @db.connection_context()
-def generate_course_provider_pages() -> Generator[GeneratedDocument, None, None]:
+def generate_course_provider_pages() -> Generator[GeneratedDocument]:
     for course_provider in CourseProvider.listing():
         yield GeneratedDocument(
             path=f"courses/{course_provider.slug}.md",
@@ -197,7 +197,7 @@ def generate_course_provider_pages() -> Generator[GeneratedDocument, None, None]
 
 
 @db.connection_context()
-def generate_newsletter_issue_pages() -> Generator[GeneratedDocument, None, None]:
+def generate_newsletter_issue_pages() -> Generator[GeneratedDocument]:
     for newsletter_issue in NewsletterIssue.listing():
         yield GeneratedDocument(
             path=f"news/{newsletter_issue.slug}.md",

--- a/tests/test_models_course_provider.py
+++ b/tests/test_models_course_provider.py
@@ -27,7 +27,7 @@ def create_partner(slug: str, **kwargs) -> Partner:
 
 
 @pytest.fixture
-def test_db() -> Generator[SqliteDatabase, None, None]:
+def test_db() -> Generator[SqliteDatabase]:
     yield from prepare_test_db([CourseProvider, Sponsor, SponsorTier, Partner])
 
 

--- a/tests/test_models_partner.py
+++ b/tests/test_models_partner.py
@@ -15,7 +15,7 @@ def create_partner(slug: str, **kwargs) -> Partner:
 
 
 @pytest.fixture
-def test_db() -> Generator[SqliteDatabase, None, None]:
+def test_db() -> Generator[SqliteDatabase]:
     yield from prepare_test_db(
         [
             Partner,

--- a/tests/test_models_role.py
+++ b/tests/test_models_role.py
@@ -14,7 +14,7 @@ def create_user(id_, **kwargs) -> ClubUser:
 
 
 @pytest.fixture
-def test_db() -> Generator[SqliteDatabase, None, None]:
+def test_db() -> Generator[SqliteDatabase]:
     yield from prepare_test_db([ClubUser, InterestRole])
 
 

--- a/tests/test_models_sponsor.py
+++ b/tests/test_models_sponsor.py
@@ -16,7 +16,7 @@ def create_sponsor(slug: str, **kwargs) -> Sponsor:
 
 
 @pytest.fixture
-def test_db() -> Generator[SqliteDatabase, None, None]:
+def test_db() -> Generator[SqliteDatabase]:
     yield from prepare_test_db(
         [
             Sponsor,

--- a/tests/test_models_stage.py
+++ b/tests/test_models_stage.py
@@ -12,7 +12,7 @@ from testing_utils import prepare_test_db
 
 
 @pytest.fixture
-def test_db() -> Generator[SqliteDatabase, None, None]:
+def test_db() -> Generator[SqliteDatabase]:
     yield from prepare_test_db([Stage, Page])
 
 

--- a/tests/test_models_topic.py
+++ b/tests/test_models_topic.py
@@ -9,7 +9,7 @@ from testing_utils import prepare_test_db
 
 
 @pytest.fixture
-def test_db() -> Generator[SqliteDatabase, None, None]:
+def test_db() -> Generator[SqliteDatabase]:
     yield from prepare_test_db([TopicMention, TopicDiscussion])
 
 

--- a/tests/testing_utils.py
+++ b/tests/testing_utils.py
@@ -9,7 +9,7 @@ from peewee import SqliteDatabase
 from jg.coop.models.base import BaseModel, db as production_db
 
 
-def prepare_test_db(models: list[BaseModel]) -> Generator[SqliteDatabase, None, None]:
+def prepare_test_db(models: list[BaseModel]) -> Generator[SqliteDatabase]:
     """
     Prepares a temporary in-memory SQLite database with the given models
     and the same custom functions as on the production database.


### PR DESCRIPTION
## Motivation

Continues the incremental, rule-by-rule Ruff rollout requested in #1690 and continued by #1698 (`C408`) and #1700 (`FURB167`). One rule per PR, done serially to avoid merge conflicts.

This PR enables **`UP043`** (`unnecessary-default-type-args`).

## Description

- Add `"UP043"` to `[tool.ruff.lint].select` in `pyproject.toml`.
- Apply the autofix, removing redundant trailing default type arguments:
  - `Generator[X, None, None]` → `Generator[X]`
  - `AsyncGenerator[X, None]` → `AsyncGenerator[X]`
  - 30 occurrences across 20 files.
- `ruff format` unwrapped two signatures that no longer needed to span multiple lines.

The change is behavior-preserving — the removed arguments are the defaults the typing constructs already assume.

## Testing

- `uv run ruff check` → clean
- `uv run ruff format --check` → clean
- `uv run pytest` → **1114 passed, 1 skipped** (no regressions)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WpQu1qR3mFeNPFnbvowGf9)_