### PR TITLE
Enable Ruff UP035 and move deprecated typing imports to collections.abc

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,7 +88,7 @@ asyncio_default_fixture_loop_scope = "function"
 target-version = "py313"
 
 [tool.ruff.lint]
-select = ["C408", "E4", "E7", "E9", "F", "FURB167", "I", "UP043"]
+select = ["C408", "E4", "E7", "E9", "F", "FURB167", "I", "UP035", "UP043"]
 
 [tool.ruff.lint.isort]
 combine-as-imports = true

--- a/src/jg/coop/cli/cache.py
+++ b/src/jg/coop/cli/cache.py
@@ -1,7 +1,7 @@
 from collections import Counter
+from collections.abc import Iterable
 from pathlib import Path
 from sqlite3 import OperationalError
-from typing import Iterable
 
 import click
 from diskcache.core import DBNAME

--- a/src/jg/coop/cli/notes.py
+++ b/src/jg/coop/cli/notes.py
@@ -1,8 +1,8 @@
 import asyncio
 import re
 from collections import defaultdict
+from collections.abc import Iterable
 from pathlib import Path
-from typing import Iterable
 
 import click
 import discord

--- a/src/jg/coop/cli/tidy.py
+++ b/src/jg/coop/cli/tidy.py
@@ -4,10 +4,10 @@ import mimetypes
 import os
 import re
 import subprocess
+from collections.abc import Iterable
 from glob import glob
 from io import BytesIO
 from pathlib import Path
-from typing import Iterable
 
 import click
 from PIL import Image

--- a/src/jg/coop/lib/async_utils.py
+++ b/src/jg/coop/lib/async_utils.py
@@ -1,6 +1,6 @@
 import asyncio
+from collections.abc import Awaitable, Callable
 from functools import partial, wraps
-from typing import Awaitable, Callable
 
 
 semaphores = {}

--- a/src/jg/coop/lib/buttondown.py
+++ b/src/jg/coop/lib/buttondown.py
@@ -1,8 +1,9 @@
 import logging
 import os
+from collections.abc import AsyncGenerator
 from datetime import date
 from enum import StrEnum
-from typing import AsyncGenerator, Self, TypeVar
+from typing import Self, TypeVar
 
 import httpx
 from tenacity import (

--- a/src/jg/coop/lib/cache.py
+++ b/src/jg/coop/lib/cache.py
@@ -1,8 +1,9 @@
 import asyncio
 import logging
+from collections.abc import Callable
 from datetime import timedelta
 from functools import lru_cache, wraps
-from typing import Any, Callable
+from typing import Any
 
 from diskcache import Cache
 from diskcache.core import ENOVAL, args_to_key, full_name

--- a/src/jg/coop/lib/charts.py
+++ b/src/jg/coop/lib/charts.py
@@ -1,10 +1,11 @@
 import calendar
 import itertools
 from collections import defaultdict
+from collections.abc import Callable, Generator, Iterable
 from datetime import date, timedelta
 from functools import cache
 from numbers import Number
-from typing import Callable, Generator, Iterable, TypeVar
+from typing import TypeVar
 
 from slugify import slugify
 

--- a/src/jg/coop/lib/cli.py
+++ b/src/jg/coop/lib/cli.py
@@ -1,10 +1,10 @@
 import asyncio
 import pkgutil
 import threading
+from collections.abc import Awaitable, Callable, Generator
 from functools import wraps
 from importlib import import_module
 from types import ModuleType
-from typing import Awaitable, Callable, Generator
 
 import click
 

--- a/src/jg/coop/lib/discord_club.py
+++ b/src/jg/coop/lib/discord_club.py
@@ -1,11 +1,12 @@
 import asyncio
 import itertools
 import re
+from collections.abc import AsyncGenerator
 from datetime import date, datetime, timedelta, timezone
 from enum import IntEnum, StrEnum, unique
 from functools import wraps
 from pprint import pformat
-from typing import TYPE_CHECKING, AsyncGenerator, TypedDict
+from typing import TYPE_CHECKING, TypedDict
 
 import discord
 import emoji

--- a/src/jg/coop/lib/discord_task.py
+++ b/src/jg/coop/lib/discord_task.py
@@ -2,8 +2,8 @@ import asyncio
 import os
 import sys
 import threading
+from collections.abc import Awaitable, Callable
 from queue import Queue
-from typing import Awaitable, Callable
 
 from jg.coop.lib import loggers
 from jg.coop.lib.discord_club import ClubClient

--- a/src/jg/coop/lib/images.py
+++ b/src/jg/coop/lib/images.py
@@ -4,12 +4,13 @@ import os
 import pickle
 import shutil
 import time
+from collections.abc import Callable, Generator, Iterable
 from functools import lru_cache
 from hashlib import sha256
 from io import BytesIO
 from pathlib import Path
 from subprocess import run
-from typing import Any, Callable, Generator, Iterable
+from typing import Any
 
 from fontTools.ttLib import TTFont
 from fontTools.ttLib.tables._c_m_a_p import CmapSubtable

--- a/src/jg/coop/lib/location.py
+++ b/src/jg/coop/lib/location.py
@@ -1,10 +1,11 @@
 import os
 import random
 import re
+from collections.abc import Generator
 from datetime import timedelta
 from decimal import Decimal
 from enum import StrEnum
-from typing import Generator, Literal
+from typing import Literal
 
 import czech_sort
 import httpx

--- a/src/jg/coop/lib/loggers.py
+++ b/src/jg/coop/lib/loggers.py
@@ -2,8 +2,9 @@ import logging
 import os
 import threading
 import time
+from collections.abc import Callable, Generator, Iterable
 from pathlib import Path
-from typing import Callable, Generator, Iterable, TypeVar, cast
+from typing import TypeVar, cast
 
 import click
 

--- a/src/jg/coop/lib/memberful.py
+++ b/src/jg/coop/lib/memberful.py
@@ -3,9 +3,10 @@ import json
 import logging
 import os
 import re
+from collections.abc import Callable, Generator
 from dataclasses import dataclass
 from datetime import date, datetime, timedelta, timezone
-from typing import Any, Callable, Generator
+from typing import Any
 
 import httpx
 from gql import Client, gql

--- a/src/jg/coop/lib/mkdocs_jinja.py
+++ b/src/jg/coop/lib/mkdocs_jinja.py
@@ -1,5 +1,5 @@
+from collections.abc import Callable
 from pathlib import Path
-from typing import Callable
 
 from jinja2 import Environment as BaseEnvironment, FileSystemLoader
 from mkdocs.config import Config

--- a/src/jg/coop/lib/mutations.py
+++ b/src/jg/coop/lib/mutations.py
@@ -1,7 +1,8 @@
 import inspect
+from collections.abc import Generator, Iterable
 from contextlib import contextmanager
 from functools import partial, wraps
-from typing import Any, Generator, Iterable, Literal
+from typing import Any, Literal
 
 from jg.coop.lib import loggers
 from jg.coop.lib.cache import get_cache

--- a/src/jg/coop/lib/template_filters.py
+++ b/src/jg/coop/lib/template_filters.py
@@ -1,10 +1,11 @@
 import math
 import random
 import re
+from collections.abc import Generator, Iterable
 from datetime import UTC, timedelta
 from numbers import Number
 from operator import itemgetter
-from typing import Generator, Iterable, Literal
+from typing import Literal
 from urllib.parse import unquote, urljoin, urlparse, urlunparse
 from zoneinfo import ZoneInfo
 

--- a/src/jg/coop/models/base.py
+++ b/src/jg/coop/models/base.py
@@ -3,11 +3,10 @@ import hashlib
 import json
 import pickle
 import sqlite3
-from collections.abc import Set
+from collections.abc import Iterable, Set
 from enum import Enum
 from functools import cache, wraps
 from pathlib import Path
-from typing import Iterable
 
 from czech_sort import bytes_key as czech_sort_key
 from peewee import (

--- a/src/jg/coop/models/blog.py
+++ b/src/jg/coop/models/blog.py
@@ -1,4 +1,5 @@
-from typing import Iterable, Self
+from collections.abc import Iterable
+from typing import Self
 
 from peewee import CharField, DateField
 

--- a/src/jg/coop/models/candidate.py
+++ b/src/jg/coop/models/candidate.py
@@ -1,9 +1,10 @@
 import itertools
 import json
+from collections.abc import Iterable
 from datetime import date, timedelta
 from enum import StrEnum, auto
 from operator import attrgetter
-from typing import Iterable, Self
+from typing import Self
 
 from peewee import (
     BooleanField,

--- a/src/jg/coop/models/club.py
+++ b/src/jg/coop/models/club.py
@@ -1,9 +1,10 @@
 import math
+from collections.abc import Iterable
 from datetime import date, datetime, timedelta
 from enum import StrEnum, auto, unique
 from itertools import groupby
 from operator import attrgetter
-from typing import Iterable, Optional, Self, TypeVar
+from typing import Optional, Self, TypeVar
 
 from discord import ChannelType
 from peewee import (

--- a/src/jg/coop/models/course_provider.py
+++ b/src/jg/coop/models/course_provider.py
@@ -1,8 +1,9 @@
 import itertools
+from collections.abc import Iterable
 from enum import StrEnum
 from itertools import groupby
 from operator import attrgetter
-from typing import Iterable, Self
+from typing import Self
 
 import czech_sort
 from peewee import BooleanField, CharField, IntegerField, TextField, fn

--- a/src/jg/coop/models/followers.py
+++ b/src/jg/coop/models/followers.py
@@ -1,6 +1,7 @@
 import json
+from collections.abc import Iterable
 from datetime import date
-from typing import Iterable, Self
+from typing import Self
 
 from peewee import Case, CharField, IntegerField
 from playhouse.shortcuts import model_to_dict

--- a/src/jg/coop/models/job.py
+++ b/src/jg/coop/models/job.py
@@ -2,10 +2,11 @@ import itertools
 import json
 import textwrap
 from collections import Counter
+from collections.abc import Iterable
 from datetime import date, datetime, time, timedelta
 from enum import StrEnum, auto
 from operator import attrgetter
-from typing import Iterable, Self
+from typing import Self
 from urllib.parse import quote_plus
 
 from peewee import (

--- a/src/jg/coop/models/meetup.py
+++ b/src/jg/coop/models/meetup.py
@@ -1,4 +1,5 @@
-from typing import Iterable, Self
+from collections.abc import Iterable
+from typing import Self
 
 from peewee import CharField, DateTimeField
 

--- a/src/jg/coop/models/members.py
+++ b/src/jg/coop/models/members.py
@@ -1,7 +1,8 @@
 import itertools
 import json
+from collections.abc import Iterable
 from datetime import date
-from typing import Iterable, Self
+from typing import Self
 
 from peewee import CharField, IntegerField
 from playhouse.shortcuts import model_to_dict

--- a/src/jg/coop/models/newsletter.py
+++ b/src/jg/coop/models/newsletter.py
@@ -1,6 +1,7 @@
 import re
+from collections.abc import Iterable
 from datetime import datetime
-from typing import Iterable, Self
+from typing import Self
 
 from peewee import CharField, DateField, IntegerField
 

--- a/src/jg/coop/models/page.py
+++ b/src/jg/coop/models/page.py
@@ -1,4 +1,5 @@
-from typing import Iterable, Self
+from collections.abc import Iterable
+from typing import Self
 
 from peewee import BooleanField, CharField, DateField, IntegerField, fn
 

--- a/src/jg/coop/models/partner.py
+++ b/src/jg/coop/models/partner.py
@@ -1,4 +1,5 @@
-from typing import Iterable, Literal, Self
+from collections.abc import Iterable
+from typing import Literal, Self
 
 from peewee import BooleanField, CharField, DateField, IntegerField, TextField, fn
 

--- a/src/jg/coop/models/podcast.py
+++ b/src/jg/coop/models/podcast.py
@@ -1,6 +1,7 @@
 import math
+from collections.abc import Iterable
 from datetime import date, datetime, time
-from typing import Iterable, Self
+from typing import Self
 from zoneinfo import ZoneInfo
 
 from peewee import BooleanField, CharField, DateField, IntegerField

--- a/src/jg/coop/models/role.py
+++ b/src/jg/coop/models/role.py
@@ -1,5 +1,6 @@
 from collections import Counter
-from typing import Iterable, Self
+from collections.abc import Iterable
+from typing import Self
 
 from peewee import CharField, IntegerField, TextField
 

--- a/src/jg/coop/models/sponsor.py
+++ b/src/jg/coop/models/sponsor.py
@@ -1,6 +1,7 @@
+from collections.abc import Iterable
 from datetime import date
 from itertools import groupby
-from typing import Iterable, Literal, Self
+from typing import Literal, Self
 
 import czech_sort
 from peewee import (

--- a/src/jg/coop/models/stage.py
+++ b/src/jg/coop/models/stage.py
@@ -1,4 +1,5 @@
-from typing import Iterable, Self
+from collections.abc import Iterable
+from typing import Self
 
 from peewee import CharField, IntegerField
 

--- a/src/jg/coop/models/subscription.py
+++ b/src/jg/coop/models/subscription.py
@@ -1,7 +1,8 @@
 from collections import Counter
+from collections.abc import Iterable
 from datetime import date, timedelta
 from enum import StrEnum, unique
-from typing import Iterable, Self
+from typing import Self
 
 from peewee import (
     Case,

--- a/src/jg/coop/models/tip.py
+++ b/src/jg/coop/models/tip.py
@@ -1,4 +1,5 @@
-from typing import Iterable, Self
+from collections.abc import Iterable
+from typing import Self
 
 from peewee import CharField, IntegerField, TextField
 

--- a/src/jg/coop/models/transaction.py
+++ b/src/jg/coop/models/transaction.py
@@ -1,9 +1,10 @@
 import functools
 import json
 import math
+from collections.abc import Iterable
 from datetime import date
 from enum import StrEnum, unique
-from typing import Iterable, Self
+from typing import Self
 
 from peewee import CharField, DateField, IntegerField
 from playhouse.shortcuts import model_to_dict

--- a/src/jg/coop/sync/charts.py
+++ b/src/jg/coop/sync/charts.py
@@ -1,6 +1,7 @@
+from collections.abc import Callable
 from datetime import date
 from operator import attrgetter
-from typing import Any, Callable, NotRequired, TypedDict
+from typing import Any, NotRequired, TypedDict
 
 from jg.coop.cli.sync import main as cli
 from jg.coop.lib import charts, loggers

--- a/src/jg/coop/sync/club_content/crawler.py
+++ b/src/jg/coop/sync/club_content/crawler.py
@@ -1,6 +1,6 @@
 import asyncio
+from collections.abc import AsyncGenerator
 from datetime import datetime, timedelta, timezone
-from typing import AsyncGenerator
 
 from discord import ChannelType, DMChannel, Member, Message, Reaction, User
 from discord.abc import GuildChannel

--- a/src/jg/coop/sync/course_providers.py
+++ b/src/jg/coop/sync/course_providers.py
@@ -1,8 +1,8 @@
 import math
+from collections.abc import Callable
 from datetime import date, timedelta
 from functools import wraps
 from pathlib import Path
-from typing import Callable
 
 import httpx
 import yaml

--- a/src/jg/coop/sync/jobs_scraped/__init__.py
+++ b/src/jg/coop/sync/jobs_scraped/__init__.py
@@ -1,8 +1,8 @@
 import asyncio
 import importlib
 import itertools
+from collections.abc import Awaitable, Callable
 from pprint import pformat
-from typing import Awaitable, Callable
 
 from peewee import IntegrityError
 

--- a/src/jg/coop/sync/members/__init__.py
+++ b/src/jg/coop/sync/members/__init__.py
@@ -1,11 +1,12 @@
 import math
 from collections import defaultdict
+from collections.abc import Iterable
 from datetime import date, datetime
 from enum import StrEnum
 from operator import itemgetter
 from pathlib import Path
 from pprint import pformat
-from typing import DefaultDict, Iterable, Literal, TypedDict
+from typing import Literal, TypedDict
 
 import click
 from discord import NotFound
@@ -99,7 +100,7 @@ def main(history_path: Path, today: date):
 
     stats_from = today.replace(day=1)
     stats_to = today
-    stats: DefaultDict[StatName, int] = defaultdict(int)
+    stats: defaultdict[StatName, int] = defaultdict(int)
 
     for account in logger.progress(accounts):
         account_id = int(account["id"])

--- a/src/jg/coop/sync/newsletter_subscribers/__init__.py
+++ b/src/jg/coop/sync/newsletter_subscribers/__init__.py
@@ -1,7 +1,8 @@
 import asyncio
+from collections.abc import Generator
 from datetime import date
 from pathlib import Path
-from typing import Generator, TypedDict
+from typing import TypedDict
 
 import click
 

--- a/src/jg/coop/sync/organizations/__init__.py
+++ b/src/jg/coop/sync/organizations/__init__.py
@@ -1,8 +1,9 @@
 import re
+from collections.abc import Iterable
 from datetime import date, timedelta
 from operator import itemgetter
 from pathlib import Path
-from typing import Annotated, Any, Iterable, Literal, TypedDict
+from typing import Annotated, Any, Literal, TypedDict
 
 import click
 import yaml

--- a/src/jg/coop/sync/roles.py
+++ b/src/jg/coop/sync/roles.py
@@ -1,8 +1,8 @@
 import itertools
 from collections import Counter
+from collections.abc import Iterable
 from pathlib import Path
 from pprint import pformat
-from typing import Iterable
 
 import yaml
 from discord import Color, Role

--- a/src/jg/coop/sync/transactions/__init__.py
+++ b/src/jg/coop/sync/transactions/__init__.py
@@ -1,8 +1,8 @@
 import re
+from collections.abc import Callable
 from datetime import date, datetime, timedelta
 from pathlib import Path
 from pprint import pformat
-from typing import Callable
 
 import click
 import httpx

--- a/src/jg/coop/sync/transactions/categories_spec.py
+++ b/src/jg/coop/sync/transactions/categories_spec.py
@@ -1,5 +1,5 @@
+from collections.abc import Callable
 from datetime import date
-from typing import Callable
 
 from jg.coop.models.transaction import TransactionsCategory
 

--- a/src/jg/coop/web/generators.py
+++ b/src/jg/coop/web/generators.py
@@ -1,6 +1,7 @@
 from collections import Counter
+from collections.abc import Generator
 from pathlib import Path
-from typing import Any, Generator
+from typing import Any
 
 import mkdocs_gen_files
 import yaml

--- a/tests/test_models_course_provider.py
+++ b/tests/test_models_course_provider.py
@@ -1,4 +1,4 @@
-from typing import Generator
+from collections.abc import Generator
 
 import pytest
 

--- a/tests/test_models_partner.py
+++ b/tests/test_models_partner.py
@@ -1,4 +1,4 @@
-from typing import Generator
+from collections.abc import Generator
 
 import pytest
 

--- a/tests/test_models_role.py
+++ b/tests/test_models_role.py
@@ -1,4 +1,4 @@
-from typing import Generator
+from collections.abc import Generator
 
 import pytest
 

--- a/tests/test_models_sponsor.py
+++ b/tests/test_models_sponsor.py
@@ -1,5 +1,5 @@
+from collections.abc import Generator
 from datetime import date
-from typing import Generator
 
 import pytest
 

--- a/tests/test_models_stage.py
+++ b/tests/test_models_stage.py
@@ -1,6 +1,6 @@
 import random
 import uuid
-from typing import Generator
+from collections.abc import Generator
 
 import pytest
 

--- a/tests/test_models_topic.py
+++ b/tests/test_models_topic.py
@@ -1,4 +1,4 @@
-from typing import Generator
+from collections.abc import Generator
 
 import pytest
 

--- a/tests/testing_utils.py
+++ b/tests/testing_utils.py
@@ -1,7 +1,8 @@
 import random
+from collections.abc import Generator
 from datetime import date, datetime, timedelta
 from pathlib import Path
-from typing import Any, Generator
+from typing import Any
 
 import pytest
 from peewee import SqliteDatabase


### PR DESCRIPTION
## Motivation

Continues the incremental, rule-by-rule Ruff rollout requested in #1690, following #1698 (`C408`), #1700 (`FURB167`), and #1701 (`UP043`). One rule per PR, done serially to avoid merge conflicts.

This PR enables **`UP035`** (`deprecated-import`).

## Description

- Add `"UP035"` to `[tool.ruff.lint].select` in `pyproject.toml`.
- Apply the autofix (this rule's fix is `unsafe`, so `--unsafe-fixes` was needed), which:
  - imports the abstract base classes `Iterable`, `Callable`, `Generator`, `AsyncGenerator`, `Awaitable` from `collections.abc` instead of the deprecated `typing` aliases, across ~50 modules;
  - replaces `typing.DefaultDict` with `collections.defaultdict` in `sync/members/__init__.py` (the one site the autofix left for manual handling).
- isort reordered the newly added `from collections.abc import …` lines.

The moved names are identical objects (`typing.Iterable` is a deprecated alias of `collections.abc.Iterable`, etc.), so the change is behavior-preserving.

## Testing

- `uv run ruff check` → clean
- `uv run ruff format --check` → clean
- `uv run pytest` → **1114 passed, 1 skipped** (no regressions)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WpQu1qR3mFeNPFnbvowGf9)_