### PR TITLE
Enable Ruff UP017 and use the datetime.UTC alias

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,7 +88,7 @@ asyncio_default_fixture_loop_scope = "function"
 target-version = "py313"
 
 [tool.ruff.lint]
-select = ["C408", "E4", "E7", "E9", "F", "FURB167", "I", "UP035", "UP043"]
+select = ["C408", "E4", "E7", "E9", "F", "FURB167", "I", "UP017", "UP035", "UP043"]
 
 [tool.ruff.lint.isort]
 combine-as-imports = true

--- a/src/jg/coop/lib/discord_club.py
+++ b/src/jg/coop/lib/discord_club.py
@@ -2,7 +2,7 @@ import asyncio
 import itertools
 import re
 from collections.abc import AsyncGenerator
-from datetime import date, datetime, timedelta, timezone
+from datetime import UTC, date, datetime, timedelta
 from enum import IntEnum, StrEnum, unique
 from functools import wraps
 from pprint import pformat
@@ -23,7 +23,7 @@ CLUB_GUILD_ID = 769966886598737931
 DEFAULT_AUTO_ARCHIVE_DURATION = 10_080  # minutes
 
 DEFAULT_THREAD_CREATED_AT = datetime(
-    2022, 1, 9, tzinfo=timezone.utc
+    2022, 1, 9, tzinfo=UTC
 )  # threads have 'created_at' since 2022-01-09
 
 DEFAULT_CHANNELS_HISTORY_SINCE = timedelta(days=380)

--- a/src/jg/coop/lib/memberful.py
+++ b/src/jg/coop/lib/memberful.py
@@ -5,7 +5,7 @@ import os
 import re
 from collections.abc import Callable, Generator
 from dataclasses import dataclass
-from datetime import date, datetime, timedelta, timezone
+from datetime import UTC, date, datetime, timedelta
 from typing import Any
 
 import httpx
@@ -282,7 +282,7 @@ def is_individual_plan(plan: dict) -> bool:
 
 
 def timestamp_to_datetime(timestamp: int) -> datetime:
-    return datetime.fromtimestamp(timestamp, tz=timezone.utc).replace(tzinfo=None)
+    return datetime.fromtimestamp(timestamp, tz=UTC).replace(tzinfo=None)
 
 
 def timestamp_to_date(timestamp: int) -> date:

--- a/src/jg/coop/sync/club_content/crawler.py
+++ b/src/jg/coop/sync/club_content/crawler.py
@@ -1,6 +1,6 @@
 import asyncio
 from collections.abc import AsyncGenerator
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta
 
 from discord import ChannelType, DMChannel, Member, Message, Reaction, User
 from discord.abc import GuildChannel
@@ -246,5 +246,5 @@ def get_history_after(
         if now.tzinfo is None:
             raise ValueError("now must be timezone-aware")
     else:
-        now = datetime.now(timezone.utc)
+        now = datetime.now(UTC)
     return now - history_since

--- a/src/jg/coop/sync/subscriptions_align.py
+++ b/src/jg/coop/sync/subscriptions_align.py
@@ -1,5 +1,5 @@
 import itertools
-from datetime import date, datetime, time, timedelta, timezone
+from datetime import UTC, date, datetime, time, timedelta
 
 from jg.coop.cli.sync import main as cli
 from jg.coop.lib import loggers, mutations
@@ -31,7 +31,7 @@ def main():
         if org.subscription_id:
             renews_on = getattr(org, "renews_on", today + timedelta(days=365))
             logger.info(f"Organization {org.slug!r} renews on {renews_on}")
-            renews_at = datetime.combine(renews_on, time(tzinfo=timezone.utc))
+            renews_at = datetime.combine(renews_on, time(tzinfo=UTC))
             params = {
                 "id": org.subscription_id,
                 "expiresAt": int(renews_at.timestamp()),

--- a/tests/test_lib_discord_club.py
+++ b/tests/test_lib_discord_club.py
@@ -1,5 +1,5 @@
 from collections import namedtuple
-from datetime import date, datetime, timedelta, timezone
+from datetime import UTC, date, datetime, timedelta
 
 import pytest
 from discord import ChannelType, Route
@@ -370,7 +370,7 @@ def test_is_member_user():
 
 def test_is_member_member():
     StubMember = namedtuple("Member", ["id", "joined_at"])
-    member = StubMember(1, datetime(2021, 1, 1, tzinfo=timezone.utc))
+    member = StubMember(1, datetime(2021, 1, 1, tzinfo=UTC))
 
     assert discord_club.is_member(member) is True
 

--- a/tests/test_sync_club_content_crawler.py
+++ b/tests/test_sync_club_content_crawler.py
@@ -1,6 +1,6 @@
 import logging
 from collections import namedtuple
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta
 
 import pytest
 
@@ -14,10 +14,10 @@ def test_get_history_after_given_naive_datetime():
 
 def test_get_history_after_given_timezone_aware_datetime():
     history_after = get_history_after(
-        timedelta(days=2), now=datetime(2023, 8, 30, tzinfo=timezone.utc)
+        timedelta(days=2), now=datetime(2023, 8, 30, tzinfo=UTC)
     )
 
-    assert history_after == datetime(2023, 8, 28, tzinfo=timezone.utc)
+    assert history_after == datetime(2023, 8, 28, tzinfo=UTC)
 
 
 def test_get_channel_logger():


### PR DESCRIPTION
## Motivation

Continues the incremental, rule-by-rule Ruff rollout requested in #1690, following #1698 (`C408`), #1700 (`FURB167`), #1701 (`UP043`), and #1702 (`UP035`). One rule per PR, done serially to avoid merge conflicts.

This PR enables **`UP017`** (`datetime-timezone-utc`).

## Description

- Add `"UP017"` to `[tool.ruff.lint].select` in `pyproject.toml`.
- Apply the autofix, replacing `timezone.utc` with the `datetime.UTC` alias (Python 3.11+) across 4 source modules and 2 test files.
- The now-unused `timezone` imports were dropped and `UTC` added; isort reordered the remaining `datetime` imports.

`datetime.UTC` is an alias for `datetime.timezone.utc`, so the change is behavior-preserving.

## Testing

- `uv run ruff check` → clean
- `uv run ruff format --check` → clean
- `uv run pytest` → **1114 passed, 1 skipped** (no regressions)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WpQu1qR3mFeNPFnbvowGf9)_