### PR TITLE
Enable Ruff UP034 and remove extraneous parentheses

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,7 +88,7 @@ asyncio_default_fixture_loop_scope = "function"
 target-version = "py313"
 
 [tool.ruff.lint]
-select = ["C408", "E4", "E7", "E9", "F", "FURB167", "I", "UP017", "UP035", "UP043"]
+select = ["C408", "E4", "E7", "E9", "F", "FURB167", "I", "UP017", "UP034", "UP035", "UP043"]
 
 [tool.ruff.lint.isort]
 combine-as-imports = true

--- a/src/jg/coop/cli/dev.py
+++ b/src/jg/coop/cli/dev.py
@@ -84,11 +84,9 @@ def upgrade_lychee(ci_config_path: Path | str):
     response = httpx.get(api_url)
     response.raise_for_status()
     linux_musl = next(
-        (
-            asset
-            for asset in response.json().get("assets", [])
-            if "x86_64-unknown-linux-musl" in asset["name"]
-        )
+        asset
+        for asset in response.json().get("assets", [])
+        if "x86_64-unknown-linux-musl" in asset["name"]
     )
     download_url = linux_musl["browser_download_url"]
     logger.debug(f"Latest lychee release download URL: {download_url}")

--- a/src/jg/coop/sync/digest.py
+++ b/src/jg/coop/sync/digest.py
@@ -115,7 +115,7 @@ def format_channel_digest(channel_digest: dict) -> str:
 
 
 def format_content(content: str) -> str:
-    text = md_as_text(neutralize_urls((content)), newline=" ")
+    text = md_as_text(neutralize_urls(content), newline=" ")
     text_short = textwrap.shorten(text, 150, placeholder="…")
     return f"> {text_short}"
 

--- a/src/jg/coop/sync/jobs_logos.py
+++ b/src/jg/coop/sync/jobs_logos.py
@@ -79,13 +79,11 @@ def main(actor_name: str, clear_files: bool):
     logger.info("Collecting logo URLs")
     source_urls = sorted(
         set(
-            (
-                url
-                for url in itertools.chain.from_iterable(
-                    job.company_logo_source_urls for job in jobs
-                )
-                if url.startswith(("http://", "https://"))
+            url
+            for url in itertools.chain.from_iterable(
+                job.company_logo_source_urls for job in jobs
             )
+            if url.startswith(("http://", "https://"))
         )
     )
     try:

--- a/src/jg/coop/sync/organizations/__init__.py
+++ b/src/jg/coop/sync/organizations/__init__.py
@@ -344,7 +344,7 @@ def prepare_tiers(
     )
     for tier_name, data in (extras or {}).items():
         try:
-            tier = next((tier for tier in tiers if tier["name"] == tier_name))
+            tier = next(tier for tier in tiers if tier["name"] == tier_name)
             tier.update(data)
         except StopIteration:
             raise ValueError(f"Tier {tier_name!r} not found")

--- a/tests/test_lib_md.py
+++ b/tests/test_lib_md.py
@@ -7,7 +7,7 @@ def test_md():
 
 
 def test_md_headings():
-    markup = md(("# heading1\n## heading2\n### heading3\n"))
+    markup = md("# heading1\n## heading2\n### heading3\n")
     assert str(markup) == (
         '<h1 id="heading1">heading1</h1>\n'
         '<h2 id="heading2">heading2</h2>\n'


### PR DESCRIPTION
## Motivation

Continues the incremental, rule-by-rule Ruff rollout requested in #1690, following #1698 (`C408`), #1700 (`FURB167`), #1701 (`UP043`), #1702 (`UP035`), and #1703 (`UP017`). One rule per PR, done serially to avoid merge conflicts.

This PR enables **`UP034`** (`extraneous-parentheses`).

## Description

- Add `"UP034"` to `[tool.ruff.lint].select` in `pyproject.toml`.
- Apply the autofix, removing redundant parentheses — around generator expressions passed to `next(...)` / `set(...)`, and a doubled paren around a function argument (`neutralize_urls((content))` → `neutralize_urls(content)`). 5 sites.
- `ruff format` rewrapped two call sites the removed parens left over-nested.

Behavior-preserving.

## Testing

- `uv run ruff check` → clean
- `uv run ruff format --check` → clean
- `uv run pytest` → **1114 passed, 1 skipped** (no regressions)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WpQu1qR3mFeNPFnbvowGf9)_