### PR TITLE
Enable Ruff RUF100 and remove dead noqa directives

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,7 +88,7 @@ asyncio_default_fixture_loop_scope = "function"
 target-version = "py313"
 
 [tool.ruff.lint]
-select = ["C408", "E4", "E7", "E9", "F", "FURB167", "I", "UP017", "UP034", "UP035", "UP043"]
+select = ["C408", "E4", "E7", "E9", "F", "FURB167", "I", "RUF100", "UP017", "UP034", "UP035", "UP043"]
 
 [tool.ruff.lint.isort]
 combine-as-imports = true

--- a/src/jg/coop/models/event.py
+++ b/src/jg/coop/models/event.py
@@ -227,7 +227,7 @@ class Event(BaseModel):
         if has_recording:
             query = query.where(
                 (cls.club_recording_url.is_null(False))
-                | (cls.public_recording_url.is_null(False))  # noqa: E712
+                | (cls.public_recording_url.is_null(False))
             )
         if has_avatar:
             query = query.where(cls.avatar_path != cls.avatar_path.default)
@@ -280,7 +280,7 @@ class Event(BaseModel):
             cls.select()
             .where(
                 (cls.club_recording_url.is_null(False))
-                | (cls.public_recording_url.is_null(False))  # noqa: E712
+                | (cls.public_recording_url.is_null(False))
             )
             .count()
         )


### PR DESCRIPTION
## Motivation

Continues the incremental, rule-by-rule Ruff rollout requested in #1690, following #1698 (`C408`), #1700 (`FURB167`), #1701 (`UP043`), #1702 (`UP035`), #1703 (`UP017`), and #1704 (`UP034`). One rule per PR, done serially to avoid merge conflicts.

This PR enables **`RUF100`** (`unused-noqa`).

## Description

- Add `"RUF100"` to `[tool.ruff.lint].select` in `pyproject.toml`.
- Apply the autofix, removing two stale `# noqa: E712` directives in `models/event.py`. Those sat on `.is_null(False)` expressions — there's no `== True` comparison on those lines, so E712 never fired there and the directives were dead (copy-paste leftovers).

Note: the many *intentional* `# noqa: E712` directives on real peewee `field == True` comparisons are **kept** — E712 is enabled through the `E7` selection, so those directives are genuinely in use and RUF100 does not flag them. Only the two truly-unused ones are removed.

## Testing

- `uv run ruff check` → clean
- `uv run ruff format --check` → clean
- `uv run pytest` → **1114 passed, 1 skipped** (no regressions)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WpQu1qR3mFeNPFnbvowGf9)_