### PR TITLE
Enable Ruff UP047 and adopt PEP 695 generic function syntax

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,7 +88,7 @@ asyncio_default_fixture_loop_scope = "function"
 target-version = "py313"
 
 [tool.ruff.lint]
-select = ["C408", "E4", "E7", "E9", "F", "FURB167", "I", "RUF100", "UP017", "UP034", "UP035", "UP043"]
+select = ["C408", "E4", "E7", "E9", "F", "FURB167", "I", "RUF100", "UP017", "UP034", "UP035", "UP043", "UP047"]
 
 [tool.ruff.lint.isort]
 combine-as-imports = true

--- a/src/jg/coop/lib/charts.py
+++ b/src/jg/coop/lib/charts.py
@@ -5,12 +5,8 @@ from collections.abc import Callable, Generator, Iterable
 from datetime import date, timedelta
 from functools import cache
 from numbers import Number
-from typing import TypeVar
 
 from slugify import slugify
-
-
-T = TypeVar("T")
 
 
 ANNOTATION_LABEL_OPTIONS = {
@@ -79,7 +75,7 @@ def month_end(day: date) -> date:
     return month_range(day)[1]
 
 
-def group_by_month_end(
+def group_by_month_end[T](
     items: Iterable[T], day_fn: Callable[[T], date]
 ) -> dict[date, list[T]]:
     grouped = defaultdict(list)
@@ -113,7 +109,7 @@ def yoy_growth_ptc(
     return growth_ptc(counts_fn(months), counts_fn(years_ago))
 
 
-def per_month_aggregate_breakdown(
+def per_month_aggregate_breakdown[T](
     items: Iterable[T],
     day_fn: Callable[[T], date],
     value_fns: dict[str, Callable[[T], Number]],

--- a/src/jg/coop/lib/llm.py
+++ b/src/jg/coop/lib/llm.py
@@ -4,7 +4,7 @@ from datetime import timedelta
 from enum import StrEnum
 from functools import lru_cache
 from textwrap import dedent
-from typing import TypeVar, overload
+from typing import overload
 
 import tiktoken
 from openai import AsyncOpenAI, InternalServerError, RateLimitError
@@ -30,9 +30,6 @@ OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
 logger = loggers.from_path(__file__)
 
 
-Schema = TypeVar("T", bound=BaseModel)
-
-
 class LLMModel(StrEnum):
     simple = "gpt-4o-mini"
     medium = "gpt-4.1-mini"
@@ -56,7 +53,7 @@ async def ask_llm(
 
 
 @overload
-async def ask_llm(
+async def ask_llm[Schema: BaseModel](
     system_prompt: str,
     user_prompt: str,
     model: LLMModel = LLMModel.simple,
@@ -100,7 +97,7 @@ retry_defaults = {
     **retry_defaults,
 )
 @cache(expire=timedelta(days=60), tag="llm")
-async def ask_llm(
+async def ask_llm[Schema: BaseModel](
     system_prompt: str,
     user_prompt: str,
     model: LLMModel = LLMModel.simple,

--- a/src/jg/coop/models/club.py
+++ b/src/jg/coop/models/club.py
@@ -4,7 +4,7 @@ from datetime import date, datetime, timedelta
 from enum import StrEnum, auto, unique
 from itertools import groupby
 from operator import attrgetter
-from typing import Optional, Self, TypeVar
+from typing import Optional, Self
 
 from discord import ChannelType
 from peewee import (
@@ -25,8 +25,6 @@ from jg.coop.lib.discord_club import (
 )
 from jg.coop.models.base import BaseModel, JSONField, check_enum
 
-
-T = TypeVar("T")
 
 TOP_MEMBERS_PERCENT = 0.05
 
@@ -579,14 +577,14 @@ class ClubPin(BaseModel):
         )
 
 
-def non_empty_min(values: Iterable[T | None]) -> T | None:
+def non_empty_min[T](values: Iterable[T | None]) -> T | None:
     values = list(filter(None, values))
     if values:
         return min(values)
     return None
 
 
-def non_empty_max(values: Iterable[T | None]) -> T | None:
+def non_empty_max[T](values: Iterable[T | None]) -> T | None:
     values = list(filter(None, values))
     if values:
         return max(values)


### PR DESCRIPTION
## Motivation

Continues the incremental, rule-by-rule Ruff rollout requested in #1690, following #1698 (`C408`), #1700 (`FURB167`), #1701 (`UP043`), #1702 (`UP035`), #1703 (`UP017`), #1704 (`UP034`), and #1705 (`RUF100`). One rule per PR, done serially to avoid merge conflicts.

This PR enables **`UP047`** (`non-pep695-generic-function`).

## Description

- Add `"UP047"` to `[tool.ruff.lint].select` in `pyproject.toml`.
- Apply the autofix (`--unsafe-fixes`), converting the `TypeVar`-parameterised generic functions to the PEP 695 `def fn[T](...)` form:
  - `group_by_month_end`, `per_month_aggregate_breakdown` (`lib/charts.py`)
  - `ask_llm` overload + impl → `ask_llm[Schema: BaseModel]` (`lib/llm.py`)
  - `non_empty_min`, `non_empty_max` (`models/club.py`)
- Remove the now-unused module-level `TypeVar` definitions (`T = TypeVar("T")`, `Schema = TypeVar(...)`) and drop `TypeVar` from the affected `typing` imports. The autofix leaves these behind (ruff doesn't flag unused module-level assignments), so they're cleaned up manually here.

The type parameters are function-scoped equivalents of the old module-level `TypeVar`s, so the change is behavior-preserving.

## Testing

- `uv run ruff check` → clean
- `uv run ruff format --check` → clean
- `uv run pytest` → **1114 passed, 1 skipped** (no regressions)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WpQu1qR3mFeNPFnbvowGf9)_