### PR TITLE
Enable Ruff RUF015 and use next() for first-element access

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,7 +88,7 @@ asyncio_default_fixture_loop_scope = "function"
 target-version = "py313"
 
 [tool.ruff.lint]
-select = ["C408", "E4", "E7", "E9", "F", "FURB167", "I", "RUF100", "UP017", "UP034", "UP035", "UP043", "UP047"]
+select = ["C408", "E4", "E7", "E9", "F", "FURB167", "I", "RUF015", "RUF100", "UP017", "UP034", "UP035", "UP043", "UP047"]
 
 [tool.ruff.lint.isort]
 combine-as-imports = true

--- a/src/jg/coop/cli/backup.py
+++ b/src/jg/coop/cli/backup.py
@@ -159,12 +159,12 @@ def discord(template):
 async def backup_discord(client: ClubClient, template_name):
     try:
         logger.info(f"Looking for template {template_name}")
-        template = [
+        template = next(
             template
             for template in (await client.club_guild.templates())
             if template.name == template_name
-        ][0]
-    except IndexError:
+        )
+    except StopIteration:
         logger.warning(f"Not found! Creating template {template_name}")
         await client.club_guild.create_template(name=template_name)
     else:

--- a/src/jg/coop/cli/winners.py
+++ b/src/jg/coop/cli/winners.py
@@ -22,7 +22,7 @@ def main(message_url, winners_count):
 
 async def draw_winners(client: ClubClient, message_url, winners_count):
     roles = await client.club_guild.fetch_roles()
-    role = [role for role in roles if role.id == ROLE][0]
+    role = next(role for role in roles if role.id == ROLE)
     logger.info(f"Limiting winners to only those with role '{role.name}'")
 
     message_url_parts = message_url.split("/")

--- a/src/jg/coop/lib/charts.py
+++ b/src/jg/coop/lib/charts.py
@@ -157,15 +157,15 @@ def milestones(months: list[date], milestones: list[tuple[date, str]]) -> dict:
     for milestone_date, milestone_name in dict(milestones).items():
         name = slugify(milestone_name)
         try:
-            x = [
+            x = next(
                 index
                 for index, month in enumerate(months)
                 if (
                     month.year == milestone_date.year
                     and month.month == milestone_date.month
                 )
-            ][0]
-        except IndexError:
+            )
+        except StopIteration:
             continue
         else:
             annotations[f"{name}-label"] = {

--- a/src/jg/coop/sync/followers.py
+++ b/src/jg/coop/sync/followers.py
@@ -101,18 +101,18 @@ def scrape_youtube():
         response.raise_for_status()
         html_tree = html.fromstring(response.content)
         try:
-            consent_form = [
+            consent_form = next(
                 form
                 for form in html_tree.forms
                 if form.action == YOUTUBE_CONSENT_FORM_URL
-            ][0]
+            )
             response = client.request(
                 consent_form.method.lower(),
                 consent_form.action,
                 params=consent_form.form_values(),
             )
             response.raise_for_status()
-        except IndexError:
+        except StopIteration:
             logger.warning("There is no YouTube consent form")
         match = re.search(r'"(\d+) (odběratelů|subscribers)"', response.text)
         try:

--- a/src/jg/coop/sync/pages.py
+++ b/src/jg/coop/sync/pages.py
@@ -92,7 +92,7 @@ def parse_notes(source: str) -> str:
 
 
 def get_nav_names(src_uri: str, nav: Navigation) -> tuple[str, str]:
-    nav_item = [item for item in nav.pages if item.file.src_uri == src_uri][0]
+    nav_item = next(item for item in nav.pages if item.file.src_uri == src_uri)
     return (list(nav_item.ancestors)[-1].title, nav_item.title)
 
 


### PR DESCRIPTION
## Motivation

Continues the incremental, rule-by-rule Ruff rollout requested in #1690, following #1698 (`C408`), #1700 (`FURB167`), #1701 (`UP043`), #1702 (`UP035`), #1703 (`UP017`), #1704 (`UP034`), #1705 (`RUF100`), and #1706 (`UP047`). One rule per PR, done serially to avoid merge conflicts.

This PR enables **`RUF015`** (`unnecessary-iterable-allocation-for-first-element`).

## Description

- Add `"RUF015"` to `[tool.ruff.lint].select` in `pyproject.toml`.
- Apply the autofix (`--unsafe-fixes`), replacing `[expr for … if …][0]` list allocations with `next(expr for … if …)`, so only the first matching element is computed instead of the whole list. 5 sites.

### Behavior-preserving correction of the unsafe autofix

Three of these single-element slices sat inside `try/except IndexError`. `next()` raises **`StopIteration`**, not `IndexError`, on an empty iterator, so the handlers are updated to `except StopIteration` to keep the "not found → fallback" paths working:

- `cli/backup.py` — "template not found → create it"
- `lib/charts.py` — "milestone month not found → skip"
- `sync/followers.py` — "no YouTube consent form"

The other two sites (`cli/winners.py`, `sync/pages.py`) have no such handler and rely on the element always being present; their behavior is unchanged.

This mirrors the same care taken in the original #1690 branch.

## Testing

- `uv run ruff check` → clean
- `uv run ruff format --check` → clean
- `uv run pytest` → **1114 passed, 1 skipped** (no regressions)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WpQu1qR3mFeNPFnbvowGf9)_