### PR TITLE
Enable Ruff FURB110 and use or instead of ternary

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,7 +88,7 @@ asyncio_default_fixture_loop_scope = "function"
 target-version = "py313"
 
 [tool.ruff.lint]
-select = ["C408", "E4", "E7", "E9", "F", "FURB167", "I", "RUF015", "RUF100", "UP017", "UP034", "UP035", "UP043", "UP047"]
+select = ["C408", "E4", "E7", "E9", "F", "FURB110", "FURB167", "I", "RUF015", "RUF100", "UP017", "UP034", "UP035", "UP043", "UP047"]
 
 [tool.ruff.lint.isort]
 combine-as-imports = true

--- a/src/jg/coop/models/candidate.py
+++ b/src/jg/coop/models/candidate.py
@@ -385,7 +385,7 @@ class CandidateProject(BaseModel):
 
     @property
     def title_pretty(self) -> str:
-        return remove_emoji(self.title if self.title else self.name_repo)
+        return remove_emoji(self.title or self.name_repo)
 
     @property
     def duration(self) -> timedelta:

--- a/src/jg/coop/sync/guide_events.py
+++ b/src/jg/coop/sync/guide_events.py
@@ -71,7 +71,7 @@ def build_event_args(event: Event) -> dict:
         ui.Button(
             emoji="<:youtube:976200175490060299>",
             label="Záznam",
-            url=recording_url if recording_url else None,
+            url=recording_url or None,
             disabled=not recording_url,
         )
     )

--- a/src/jg/coop/sync/tips.py
+++ b/src/jg/coop/sync/tips.py
@@ -164,11 +164,7 @@ async def create_tip(channel: ForumChannel, tip: dict) -> Thread:
 @mutations.mutates_discord()
 async def update_tip(thread: Thread, tip: dict) -> None:
     logger.info(f"Updating tip: {tip['title']}")
-    message = (
-        thread.starting_message
-        if thread.starting_message
-        else (await thread.fetch_message(thread.id))
-    )
+    message = thread.starting_message or (await thread.fetch_message(thread.id))
     view = await create_view(tip["edit_url"])
 
     thread_params = {}


### PR DESCRIPTION
## Motivation

Continues the incremental, rule-by-rule Ruff rollout from #1690 (now serially adopting additional safe modernization rules beyond the original set). Following #1707 (`RUF015`). One rule per PR, done serially to avoid merge conflicts.

This PR enables **`FURB110`** (`if-exp-instead-of-or-operator`).

## Description

- Add `"FURB110"` to `[tool.ruff.lint].select` in `pyproject.toml`.
- Apply the autofix, replacing `x if x else y` ternaries with the equivalent `x or y`:
  - `models/candidate.py` — `self.title if self.title else self.name_repo` → `self.title or self.name_repo`
  - `sync/guide_events.py` — `recording_url if recording_url else None` → `recording_url or None`
  - `sync/tips.py` — `thread.starting_message if thread.starting_message else (await …)` → `thread.starting_message or (await …)`

Behavior-preserving; `ruff format` collapsed the one multi-line ternary.

## Testing

- `uv run ruff check` → clean
- `uv run ruff format --check` → clean
- `uv run pytest` → **1114 passed, 1 skipped** (no regressions)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WpQu1qR3mFeNPFnbvowGf9)_