### PR TITLE
Enable Ruff C420 and use dict.fromkeys

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,7 +88,7 @@ asyncio_default_fixture_loop_scope = "function"
 target-version = "py313"
 
 [tool.ruff.lint]
-select = ["C408", "E4", "E7", "E9", "F", "FURB110", "FURB167", "I", "RUF015", "RUF100", "UP017", "UP034", "UP035", "UP043", "UP047"]
+select = ["C408", "C420", "E4", "E7", "E9", "F", "FURB110", "FURB167", "I", "RUF015", "RUF100", "UP017", "UP034", "UP035", "UP043", "UP047"]
 
 [tool.ruff.lint.isort]
 combine-as-imports = true

--- a/src/jg/coop/models/followers.py
+++ b/src/jg/coop/models/followers.py
@@ -55,7 +55,7 @@ class Followers(BaseModel):
 
     @classmethod
     def breakdown(cls, date: date) -> dict[str, int]:
-        breakdown = {name: None for name in cls.names()}
+        breakdown = dict.fromkeys(cls.names())
         for followers in cls.select().where(cls.month == f"{date:%Y-%m}"):
             breakdown[followers.name] = followers.count
         return breakdown

--- a/src/jg/coop/models/subscription.py
+++ b/src/jg/coop/models/subscription.py
@@ -284,4 +284,4 @@ def get_breakdown_ptc(counter: dict, enum: StrEnum | None = None) -> dict[str, f
         types = [type.value for type in enum]
     if total_count := sum(counter.values()):
         return {type: (counter[type] / total_count) * 100 for type in types}
-    return {type: 0 for type in types}
+    return dict.fromkeys(types, 0)

--- a/src/jg/coop/models/web_usage.py
+++ b/src/jg/coop/models/web_usage.py
@@ -23,7 +23,7 @@ class WebUsage(BaseModel):
 
     @classmethod
     def breakdown(cls, date: date) -> dict[str, int]:
-        breakdown = {product_slug: 0 for product_slug in cls.products()}
+        breakdown = dict.fromkeys(cls.products(), 0)
         for usage in cls.select().where(cls.month_starts_on == date.replace(day=1)):
             breakdown[usage.product_slug] = max(
                 breakdown[usage.product_slug], usage.pageviews


### PR DESCRIPTION
## Motivation

Continues the incremental, rule-by-rule Ruff rollout from #1690, following #1708 (`FURB110`). One rule per PR, done serially to avoid merge conflicts.

This PR enables **`C420`** (`unnecessary-dict-comprehension-for-iterable`).

## Description

- Add `"C420"` to `[tool.ruff.lint].select` in `pyproject.toml`.
- Apply the autofix, replacing `{k: v for k in iterable}` comprehensions with `dict.fromkeys(iterable, v)`:
  - `models/followers.py` — `{name: None for name in cls.names()}` → `dict.fromkeys(cls.names())`
  - `models/subscription.py` — `{type: 0 for type in types}` → `dict.fromkeys(types, 0)`
  - `models/web_usage.py` — `{product_slug: 0 for product_slug in cls.products()}` → `dict.fromkeys(cls.products(), 0)`

The fill values are immutable (`None`, `0`), so `dict.fromkeys` introduces no shared-mutable-default hazard; behavior-preserving.

## Testing

- `uv run ruff check` → clean
- `uv run ruff format --check` → clean
- `uv run pytest` → **1114 passed, 1 skipped** (no regressions)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WpQu1qR3mFeNPFnbvowGf9)_