### PR TITLE
Enable Ruff SIM910 and drop redundant None default from dict.get

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,7 +88,7 @@ asyncio_default_fixture_loop_scope = "function"
 target-version = "py313"
 
 [tool.ruff.lint]
-select = ["C408", "C420", "E4", "E7", "E9", "F", "FURB110", "FURB167", "I", "RUF015", "RUF100", "UP017", "UP034", "UP035", "UP043", "UP047"]
+select = ["C408", "C420", "E4", "E7", "E9", "F", "FURB110", "FURB167", "I", "RUF015", "RUF100", "SIM910", "UP017", "UP034", "UP035", "UP043", "UP047"]
 
 [tool.ruff.lint.isort]
 combine-as-imports = true

--- a/src/jg/coop/models/members.py
+++ b/src/jg/coop/models/members.py
@@ -61,7 +61,7 @@ class Members(BaseModel):
             row.month: row.count
             for row in cls.select().where(cls.name == name).order_by(cls.month)
         }
-        return [counts.get(month.strftime("%Y-%m"), None) for month in months]
+        return [counts.get(month.strftime("%Y-%m")) for month in months]
 
     @classmethod
     def monthly_members(cls, months: Iterable[date]) -> list[int]:

--- a/src/jg/coop/sync/jobs_listing.py
+++ b/src/jg/coop/sync/jobs_listing.py
@@ -52,7 +52,7 @@ def main(actor_name: str):
 
     status_by_url = {check["url"]: check["ok"] for check in checks}
     for scraped_job in scraped_jobs:
-        status = status_by_url.get(scraped_job.url, None)
+        status = status_by_url.get(scraped_job.url)
         status_for_humans = {
             None: "N/A",
             True: "OK",


### PR DESCRIPTION
## Motivation

Continues the incremental, rule-by-rule Ruff rollout from #1690, following #1709 (`C420`). One rule per PR, done serially to avoid merge conflicts.

This PR enables **`SIM910`** (`dict-get-with-none-default`).

## Description

- Add `"SIM910"` to `[tool.ruff.lint].select` in `pyproject.toml`.
- Apply the autofix, removing the explicit `None` default from `dict.get(key, None)` calls:
  - `models/members.py` — `counts.get(month.strftime("%Y-%m"), None)` → `counts.get(month.strftime("%Y-%m"))`
  - `sync/jobs_listing.py` — `status_by_url.get(scraped_job.url, None)` → `status_by_url.get(scraped_job.url)`

`dict.get` already returns `None` for a missing key, so the change is behavior-preserving.

## Testing

- `uv run ruff check` → clean
- `uv run ruff format --check` → clean
- `uv run pytest` → **1114 passed, 1 skipped** (no regressions)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WpQu1qR3mFeNPFnbvowGf9)_