### PR TITLE
Enable Ruff C413 and drop list() around sorted()

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,7 +88,7 @@ asyncio_default_fixture_loop_scope = "function"
 target-version = "py313"
 
 [tool.ruff.lint]
-select = ["C408", "C420", "E4", "E7", "E9", "F", "FURB110", "FURB167", "I", "RUF015", "RUF100", "SIM910", "UP017", "UP034", "UP035", "UP043", "UP047"]
+select = ["C408", "C413", "C420", "E4", "E7", "E9", "F", "FURB110", "FURB167", "I", "RUF015", "RUF100", "SIM910", "UP017", "UP034", "UP035", "UP043", "UP047"]
 
 [tool.ruff.lint.isort]
 combine-as-imports = true

--- a/src/jg/coop/sync/members/__init__.py
+++ b/src/jg/coop/sync/members/__init__.py
@@ -301,9 +301,7 @@ def get_coupon(subscription: SubscriptionEntity) -> str | None:
     if subscription["coupon"]:
         return subscription["coupon"]["code"]
 
-    orders = list(
-        sorted(subscription["orders"], key=itemgetter("createdAt"), reverse=True)
-    )
+    orders = sorted(subscription["orders"], key=itemgetter("createdAt"), reverse=True)
     try:
         last_order = orders[0]
         if not last_order["coupon"]:


### PR DESCRIPTION
## Motivation

Continues the incremental, rule-by-rule Ruff rollout from #1690, following #1710 (`SIM910`). One rule per PR, done serially to avoid merge conflicts.

This PR enables **`C413`** (`unnecessary-call-around-sorted`).

## Description

- Add `"C413"` to `[tool.ruff.lint].select` in `pyproject.toml`.
- Apply the autofix, removing the redundant `list()` wrapper around a `sorted()` call in `sync/members/__init__.py` (`list(sorted(...))` → `sorted(...)`), since `sorted()` already returns a list.

Behavior-preserving.

## Testing

- `uv run ruff check` → clean
- `uv run ruff format --check` → clean
- `uv run pytest` → **1114 passed, 1 skipped** (no regressions)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WpQu1qR3mFeNPFnbvowGf9)_