### PR TITLE
Enable Ruff UP011 and drop parentheses from lru_cache decorator

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,7 +88,7 @@ asyncio_default_fixture_loop_scope = "function"
 target-version = "py313"
 
 [tool.ruff.lint]
-select = ["C408", "C413", "C420", "E4", "E7", "E9", "F", "FURB110", "FURB167", "I", "RUF015", "RUF100", "SIM910", "UP017", "UP034", "UP035", "UP043", "UP047"]
+select = ["C408", "C413", "C420", "E4", "E7", "E9", "F", "FURB110", "FURB167", "I", "RUF015", "RUF100", "SIM910", "UP011", "UP017", "UP034", "UP035", "UP043", "UP047"]
 
 [tool.ruff.lint.isort]
 combine-as-imports = true

--- a/src/jg/coop/lib/cache.py
+++ b/src/jg/coop/lib/cache.py
@@ -93,6 +93,6 @@ class BytecodeCache(BaseBytecodeCache):
         self.cache.set(f"jinja:{bucket.key}", bucket.bytecode_to_string(), tag="jinja")
 
 
-@lru_cache()
+@lru_cache
 def get_jinja_cache() -> BytecodeCache:
     return BytecodeCache(get_cache())


### PR DESCRIPTION
## Motivation

Continues the incremental, rule-by-rule Ruff rollout from #1690, following #1711 (`C413`). One rule per PR, done serially to avoid merge conflicts.

This PR enables **`UP011`** (`lru-cache-without-parameters`).

## Description

- Add `"UP011"` to `[tool.ruff.lint].select` in `pyproject.toml`.
- Apply the autofix, changing the parameterless `@lru_cache()` decorator to `@lru_cache` in `lib/cache.py`.

Behavior-preserving.

## Testing

- `uv run ruff check` → clean
- `uv run ruff format --check` → clean
- `uv run pytest` → **1114 passed, 1 skipped** (no regressions)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WpQu1qR3mFeNPFnbvowGf9)_