### PR TITLE
Enable Ruff PLC0207 and use rsplit with maxsplit

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,7 +88,7 @@ asyncio_default_fixture_loop_scope = "function"
 target-version = "py313"
 
 [tool.ruff.lint]
-select = ["C408", "C413", "C420", "E4", "E7", "E9", "F", "FURB110", "FURB167", "I", "RUF015", "RUF100", "SIM910", "UP011", "UP017", "UP034", "UP035", "UP043", "UP047"]
+select = ["C408", "C413", "C420", "E4", "E7", "E9", "F", "FURB110", "FURB167", "I", "PLC0207", "RUF015", "RUF100", "SIM910", "UP011", "UP017", "UP034", "UP035", "UP043", "UP047"]
 
 [tool.ruff.lint.isort]
 combine-as-imports = true

--- a/src/jg/coop/lib/cli.py
+++ b/src/jg/coop/lib/cli.py
@@ -10,7 +10,7 @@ import click
 
 
 def command_name(module_name: str) -> str:
-    return module_name.split(".")[-1].replace("_", "-")
+    return module_name.rsplit(".", maxsplit=1)[-1].replace("_", "-")
 
 
 def import_command(name: str, import_path: str) -> click.Command:


### PR DESCRIPTION
## Motivation

Continues the incremental, rule-by-rule Ruff rollout from #1690, following #1712 (`UP011`). One rule per PR, done serially to avoid merge conflicts.

This PR enables **`PLC0207`** (`missing-maxsplit-arg`).

## Description

- Add `"PLC0207"` to `[tool.ruff.lint].select` in `pyproject.toml`.
- Apply the autofix in `lib/cli.py`, replacing `module_name.split(".")[-1]` with `module_name.rsplit(".", maxsplit=1)[-1]`, so only the final segment is split off instead of the whole string.

The indexed result is identical, so the change is behavior-preserving.

## Testing

- `uv run ruff check` → clean
- `uv run ruff format --check` → clean
- `uv run pytest` → **1114 passed, 1 skipped** (no regressions)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WpQu1qR3mFeNPFnbvowGf9)_