### PR TITLE
Enable Ruff PLC1802 and drop len() from truthiness test

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,7 +88,7 @@ asyncio_default_fixture_loop_scope = "function"
 target-version = "py313"
 
 [tool.ruff.lint]
-select = ["C408", "C413", "C420", "E4", "E7", "E9", "F", "FURB110", "FURB167", "I", "PLC0207", "RUF015", "RUF100", "SIM910", "UP011", "UP017", "UP034", "UP035", "UP043", "UP047"]
+select = ["C408", "C413", "C420", "E4", "E7", "E9", "F", "FURB110", "FURB167", "I", "PLC0207", "PLC1802", "RUF015", "RUF100", "SIM910", "UP011", "UP017", "UP034", "UP035", "UP043", "UP047"]
 
 [tool.ruff.lint.isort]
 combine-as-imports = true

--- a/src/jg/coop/lib/images.py
+++ b/src/jg/coop/lib/images.py
@@ -101,7 +101,7 @@ def render_template(
     filters: dict[str, Callable] = None,
 ) -> bytes:
     logger.info(f"Rendering {width}x{height} {template_name}")
-    if not len(list(CACHE_DIR.glob("*.css"))):
+    if not list(CACHE_DIR.glob("*.css")):
         raise FileNotFoundError(
             f"Cache {CACHE_DIR.absolute()} does not exist, run init_templates_cache() before rendering"
         )


### PR DESCRIPTION
## Motivation

Continues the incremental, rule-by-rule Ruff rollout from #1690, following #1713 (`PLC0207`). One rule per PR, done serially to avoid merge conflicts.

This PR enables **`PLC1802`** (`len-test`).

## Description

- Add `"PLC1802"` to `[tool.ruff.lint].select` in `pyproject.toml`.
- Apply the autofix in `lib/images.py`, changing `if not len(list(...)):` to `if not list(...):`, since an empty list is already falsy.

Behavior-preserving.

## Testing

- `uv run ruff check` → clean
- `uv run ruff format --check` → clean
- `uv run pytest` → **1114 passed, 1 skipped** (no regressions)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WpQu1qR3mFeNPFnbvowGf9)_