### PR TITLE
Enable Ruff comprehension and simplify rules (C401, C403, SIM102/103/117/118)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,7 +88,7 @@ asyncio_default_fixture_loop_scope = "function"
 target-version = "py313"
 
 [tool.ruff.lint]
-select = ["C408", "C413", "C420", "E4", "E7", "E9", "F", "FURB110", "FURB167", "I", "PLC0207", "PLC1802", "RUF015", "RUF100", "SIM910", "UP011", "UP017", "UP034", "UP035", "UP043", "UP047"]
+select = ["C401", "C403", "C408", "C413", "C420", "E4", "E7", "E9", "F", "FURB110", "FURB167", "I", "PLC0207", "PLC1802", "RUF015", "RUF100", "SIM102", "SIM103", "SIM117", "SIM118", "SIM910", "UP011", "UP017", "UP034", "UP035", "UP043", "UP047"]
 
 [tool.ruff.lint.isort]
 combine-as-imports = true

--- a/src/jg/coop/lib/discord_club.py
+++ b/src/jg/coop/lib/discord_club.py
@@ -411,9 +411,7 @@ def resolve_references(markdown: str, roles: dict[str, int] | None = None) -> st
 def is_forum_guide(message: discord.Message) -> bool:
     if message.id != message.channel.id:
         return False
-    if message.channel.is_pinned():
-        return True
-    return False
+    return bool(message.channel.is_pinned())
 
 
 async def sync_guide_channel(

--- a/src/jg/coop/lib/loggers.py
+++ b/src/jg/coop/lib/loggers.py
@@ -163,7 +163,10 @@ def _infer_timestamp(cached_value: bool | None, env: dict) -> bool:
         value = env.get("LOG_TIMESTAMP")
     if value is None:
         value = env.get("CI")
-    return not (not value or value.lower() in ["0", "false"])
+    if not value:
+        return False
+    is_disabled = value.lower() in ["0", "false"]
+    return not is_disabled
 
 
 def get(name) -> Logger:

--- a/src/jg/coop/lib/loggers.py
+++ b/src/jg/coop/lib/loggers.py
@@ -163,9 +163,7 @@ def _infer_timestamp(cached_value: bool | None, env: dict) -> bool:
         value = env.get("LOG_TIMESTAMP")
     if value is None:
         value = env.get("CI")
-    if not value or value.lower() in ["0", "false"]:
-        return False
-    return True
+    return not (not value or value.lower() in ["0", "false"])
 
 
 def get(name) -> Logger:

--- a/src/jg/coop/models/job.py
+++ b/src/jg/coop/models/job.py
@@ -101,7 +101,7 @@ class SubmittedJob(BaseModel):
     def to_listed(self) -> "ListedJob":
         data = {
             field_name: getattr(self, field_name, None)
-            for field_name in ListedJob._meta.fields.keys()
+            for field_name in ListedJob._meta.fields
             if (
                 field_name in self.__class__._meta.fields
                 and field_name not in ["id", "submitted_job"]
@@ -161,7 +161,7 @@ class ScrapedJob(BaseModel):
     def from_item(cls, item) -> Self:
         data = {
             field_name: item.get(field_name)
-            for field_name in cls._meta.fields.keys()
+            for field_name in cls._meta.fields
             if field_name in item
         }
         data["posted_on"] = date.fromisoformat(item["posted_on"])
@@ -171,7 +171,7 @@ class ScrapedJob(BaseModel):
         return model_to_dict(self)
 
     def merge_item(self, item):
-        for field_name in self.__class__._meta.fields.keys():
+        for field_name in self.__class__._meta.fields:
             try:
                 # use merging method if present
                 merge_method = getattr(self, f"_merge_{field_name}")
@@ -203,7 +203,7 @@ class ScrapedJob(BaseModel):
     def to_listed(self) -> "ListedJob":
         data = {
             field_name: getattr(self, field_name, None)
-            for field_name in ListedJob._meta.fields.keys()
+            for field_name in ListedJob._meta.fields
             if (
                 field_name in self.__class__._meta.fields
                 and field_name not in ["id", "submitted_job"]
@@ -346,7 +346,7 @@ class ListedJob(BaseModel):
 
     @property
     def regions(self) -> list[str]:
-        return sorted(set(location["region"] for location in self.locations or []))
+        return sorted({location["region"] for location in self.locations or []})
 
     @property
     def location_text(self) -> str | None:
@@ -420,9 +420,7 @@ class ListedJob(BaseModel):
     @classmethod
     def tags_listing(cls, tags: Iterable[str]) -> Iterable[Self]:
         tags = set(tags)
-        return [
-            job for job in cls.listing() if tags & set([tag.slug for tag in job.tags])
-        ]
+        return [job for job in cls.listing() if tags & {tag.slug for tag in job.tags}]
 
     @classmethod
     def internship_listing(cls) -> Iterable[Self]:

--- a/src/jg/coop/sync/daniel.py
+++ b/src/jg/coop/sync/daniel.py
@@ -47,8 +47,8 @@ async def send_daily_report(client: ClubClient):
             for message in daniel.list_public_messages
             if message.created_at.date() == yesterday
         ]
-        daniel_channels = set(message.parent_channel_id for message in daniel_messages)
-        daniel_threads = set(message.channel_id for message in daniel_messages)
+        daniel_channels = {message.parent_channel_id for message in daniel_messages}
+        daniel_threads = {message.channel_id for message in daniel_messages}
         daniel_content_size = sum(message.content_size for message in daniel_messages)
 
         daniel_all_messages = [
@@ -56,10 +56,10 @@ async def send_daily_report(client: ClubClient):
             for message in daniel.list_messages
             if message.created_at.date() == yesterday
         ]
-        daniel_all_channels = set(
+        daniel_all_channels = {
             message.parent_channel_id for message in daniel_all_messages
-        )
-        daniel_all_threads = set(message.channel_id for message in daniel_all_messages)
+        }
+        daniel_all_threads = {message.channel_id for message in daniel_all_messages}
         daniel_all_content_size = sum(
             message.content_size for message in daniel_all_messages
         )

--- a/src/jg/coop/sync/jobs_club.py
+++ b/src/jg/coop/sync/jobs_club.py
@@ -94,7 +94,7 @@ async def sync_jobs(client: ClubClient, channel_id: int):
 
     logger.debug("Checking if tags are in sync")
     tags_enum = set(map(str, ForumTagName))
-    tags_discord = set(t.name for t in channel.available_tags)
+    tags_discord = {t.name for t in channel.available_tags}
     if tags_enum != tags_discord:
         raise ValueError(f"Tags don't match! {tags_discord ^ tags_enum}")
 

--- a/src/jg/coop/sync/jobs_logos.py
+++ b/src/jg/coop/sync/jobs_logos.py
@@ -78,13 +78,13 @@ def main(actor_name: str, clear_files: bool):
 
     logger.info("Collecting logo URLs")
     source_urls = sorted(
-        set(
+        {
             url
             for url in itertools.chain.from_iterable(
                 job.company_logo_source_urls for job in jobs
             )
             if url.startswith(("http://", "https://"))
-        )
+        }
     )
     try:
         logger.info(f"Fetching {len(source_urls)} logo URLs")

--- a/src/jg/coop/sync/members/__init__.py
+++ b/src/jg/coop/sync/members/__init__.py
@@ -326,9 +326,10 @@ def get_subscription_type(
                 return SubscriptionType.FINAID
             if coupon.startswith("THANKYOU"):
                 return SubscriptionType.FREE
-        if trial_end_at := subscription["trialEndAt"]:
-            if timestamp_to_date(trial_end_at) >= today:
-                return SubscriptionType.TRIAL
+        if (trial_end_at := subscription["trialEndAt"]) and timestamp_to_date(
+            trial_end_at
+        ) >= today:
+            return SubscriptionType.TRIAL
         if plan["intervalUnit"] == "month":
             return SubscriptionType.MONTHLY
         if plan["intervalUnit"] == "year":

--- a/src/jg/coop/sync/newsletter/summary.py
+++ b/src/jg/coop/sync/newsletter/summary.py
@@ -266,7 +266,7 @@ def to_feed(
 
         # stats
         messages_count = len(channel_messages)
-        authors_count = len(set(m.author.id for m in channel_messages))
+        authors_count = len({m.author.id for m in channel_messages})
         reactions_count = sum(sum(m.reactions.values()) for m in channel_messages)
         content_size = sum(m.content_size for m in channel_messages)
 

--- a/src/jg/coop/sync/roles.py
+++ b/src/jg/coop/sync/roles.py
@@ -259,7 +259,7 @@ async def sync_roles(client: ClubClient):
     await manage_organization_roles(client, discord_roles, organizations)
 
     for org in organizations:
-        org_members_ids = set(member.id for member in org.list_members)
+        org_members_ids = {member.id for member in org.list_members}
         logger.debug(f"{org.slug}_members_ids: {repr_ids(members, org_members_ids)}")
         for member in members:
             changes.extend(

--- a/src/jg/coop/sync/transactions/__init__.py
+++ b/src/jg/coop/sync/transactions/__init__.py
@@ -111,7 +111,7 @@ def main(
     logger.info(f"Found {len(todos)} Fakturoid todos")
     todos = {get_todo_key(todo): todo for todo in todos}
     logger.debug(f"Mapping Fakturoid todos by key leaves {len(todos)} todos")
-    for key in todos.keys():
+    for key in todos:
         logger.debug(f"Todo key: {key!r}")
 
     logger.info("Reading history from a file")

--- a/tests/test_lib_mutations.py
+++ b/tests/test_lib_mutations.py
@@ -180,9 +180,11 @@ def test_mutating_proxy_not_allowed(nothing_allowed):
 def test_mutating_proxy_not_allowed_raises(nothing_allowed):
     obj = Something(123)
 
-    with pytest.raises(MutationsNotAllowedError):
-        with mutating("discord", obj, raises=True) as proxy:
-            proxy.method(4, 4)
+    with (
+        pytest.raises(MutationsNotAllowedError),
+        mutating("discord", obj, raises=True) as proxy,
+    ):
+        proxy.method(4, 4)
 
 
 @pytest.mark.asyncio
@@ -210,9 +212,11 @@ async def test_mutating_proxy_not_allowed_async(nothing_allowed):
 async def test_mutating_proxy_not_allowed_async_raises(nothing_allowed):
     obj = Something(123)
 
-    with pytest.raises(MutationsNotAllowedError):
-        with mutating("discord", obj, raises=True) as proxy:
-            await proxy.async_method(4, 4)
+    with (
+        pytest.raises(MutationsNotAllowedError),
+        mutating("discord", obj, raises=True) as proxy,
+    ):
+        await proxy.async_method(4, 4)
 
 
 def test_mutations_not_allowed_works_as_boolean(nothing_allowed):


### PR DESCRIPTION
## Motivation

Continues the incremental Ruff rollout from #1690, working toward adopting ruff 0.16's full default rule set. Following #1714. Small related rules are now batched per PR (rather than one PR each) to keep the count reasonable.

This PR enables **`C401`, `C403`, `SIM102`, `SIM103`, `SIM117`, `SIM118`**.

## Description

Add the six rules to `[tool.ruff.lint].select` and fix the codebase:

- **`C401` / `C403`** — rewrite `set(x for …)` and `set([x for …])` as set comprehensions (`{x for …}`), e.g. in `models/job.py` and `sync/daniel.py`.
- **`SIM118`** — drop redundant `.keys()` in `key in dict.keys()` membership tests (`models/job.py`).
- **`SIM103`** — return the boolean condition directly instead of `if cond: return True / return False` (`lib/discord_club.py`, `lib/loggers.py`).
- **`SIM102`** (manual) — collapse a nested `if` into a single `and` condition in `sync/members/__init__.py`, preserving the `:=` walrus binding.
- **`SIM117`** (manual) — merge nested `with` statements into single parenthesized multi-context `with` blocks (two tests in `test_lib_mutations.py`).

All changes are behavior-preserving.

## Testing

- `uv run ruff check` → clean
- `uv run ruff format --check` → clean
- `uv run pytest` → **1114 passed, 1 skipped** (no regressions)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WpQu1qR3mFeNPFnbvowGf9)_