### PR TITLE
Adopt ruff default rule set (extend-select + ignore) and fix remaining violations

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,7 +88,8 @@ asyncio_default_fixture_loop_scope = "function"
 target-version = "py313"
 
 [tool.ruff.lint]
-select = ["C401", "C403", "C408", "C413", "C420", "E4", "E7", "E9", "F", "FURB110", "FURB167", "I", "PLC0207", "PLC1802", "RUF015", "RUF100", "SIM102", "SIM103", "SIM117", "SIM118", "SIM910", "UP011", "UP017", "UP034", "UP035", "UP043", "UP047"]
+extend-select = ["C420", "E4", "E7", "E9", "FURB110", "I", "PLC0207", "PLC1802", "SIM910"]
+ignore = ["ASYNC210", "ASYNC221", "ASYNC251", "BLE001", "DTZ", "RUF012"]
 
 [tool.ruff.lint.isort]
 combine-as-imports = true

--- a/src/jg/coop/cli/dev.py
+++ b/src/jg/coop/cli/dev.py
@@ -16,6 +16,12 @@ from jg.coop.lib import loggers
 logger = loggers.from_path(__file__)
 
 
+def run(
+    args: list[str], *, check: bool = True, **kwargs
+) -> subprocess.CompletedProcess:
+    return subprocess.run(args, check=check, **kwargs)
+
+
 @click.group()
 def main():
     pass
@@ -31,38 +37,36 @@ def update(pull, packages, push, stash):
         logger.info("Terminating running processes")
         python_path = sys.executable
         jg_path = f"{python_path.removesuffix('3').removesuffix('/python')}/jg"
-        subprocess.run(
-            ["pgrep", "-fl", jg_path], check=False
-        )  # prints what's getting terminated
-        subprocess.run(["pkill", "-SIGTERM", "-f", jg_path], check=False)
+        run(["pgrep", "-fl", jg_path], check=False)  # prints what's getting terminated
+        run(["pkill", "-SIGTERM", "-f", jg_path], check=False)
         if stash:
             logger.info("Stashing work in progress")
-            subprocess.run(["git", "stash"], check=True)
+            run(["git", "stash"])
         if pull:
             logger.info("Pulling changes")
-            subprocess.run(["git", "pull", "--rebase", "origin", "main"], check=True)
+            run(["git", "pull", "--rebase", "origin", "main"])
         if packages:
             logger.info("Upgrading packages")
             ci_config_path = ".circleci/config.yml"
             upgrade_lychee(ci_config_path)
-            subprocess.run(["uv", "sync", "--upgrade"], check=True)
-            subprocess.run(["npm", "update"], check=True)
-            subprocess.run(["npm", "install"], check=True)
+            run(["uv", "sync", "--upgrade"])
+            run(["npm", "update"])
+            run(["npm", "install"])
             paths = ["pyproject.toml", "uv.lock", "package-lock.json", ci_config_path]
-            subprocess.run(["git", "add"] + paths, check=False)
-            subprocess.run(["git", "commit", "-m", "update packages 📦"], check=False)
+            run(["git", "add"] + paths, check=False)
+            run(["git", "commit", "-m", "update packages 📦"], check=False)
         else:
             logger.info("Installing packages")
-            subprocess.run(["uv", "install"], check=True)
-            subprocess.run(["npm", "install"], check=True)
+            run(["uv", "install"])
+            run(["npm", "install"])
         logger.info("Installing Playwright browsers")
-        subprocess.run(["playwright", "install", "firefox"], check=True)
+        run(["playwright", "install", "firefox"])
         if push:
             logger.info("Pushing changes")
-            subprocess.run(["git", "push"], check=True)
+            run(["git", "push"])
         if stash:
             logger.info("Getting work in progress back from stash")
-            subprocess.run(["git", "stash", "pop"], check=True)
+            run(["git", "stash", "pop"])
         logger.info("Removing the 'public' directory")
         shutil.rmtree("public", ignore_errors=True)
     except subprocess.CalledProcessError:
@@ -114,22 +118,19 @@ def test(verbose: bool):
 
     logger.info("Running JavaScript tests")
     try:
-        subprocess.run(
-            ["npx", "vitest", "--dir=tests", "--run", "--environment=jsdom"], check=True
-        )
+        run(["npx", "vitest", "--dir=tests", "--run", "--environment=jsdom"])
     except subprocess.CalledProcessError:
         raise click.Abort()
 
     logger.info("Linting SCSS")
     try:
-        subprocess.run(
+        run(
             [
                 "npx",
                 "stylelint",
                 "src/jg/coop/css/**/*.*css",
                 "src/jg/coop/image_templates/*.*css",
-            ],
-            check=True,
+            ]
         )
     except subprocess.CalledProcessError:
         raise click.Abort()
@@ -156,8 +157,8 @@ def deploy(public_dir: Path, commit_hash: str, build_url: str):
 @main.command()
 def reset_repo():
     try:
-        subprocess.run(["git", "reset", "--hard"], check=True)
-        subprocess.run(["git", "clean", "-f", "-d"], check=True)
+        run(["git", "reset", "--hard"])
+        run(["git", "clean", "-f", "-d"])
     except subprocess.CalledProcessError:
         raise click.Abort()
 
@@ -175,18 +176,18 @@ def save_changes(paths, message, build_url, skip_ci):
     try:
         for path in paths:
             logger["save-changes"].info(f"Adding path: {path}")
-            subprocess.run(["git", "add", "-A", str(path)], check=True)
+            run(["git", "add", "-A", str(path)])
 
-        proc = subprocess.run(
+        proc = run(
             ["git", "diff", "--name-only", "--cached"],
             stdout=subprocess.PIPE,
             check=False,
         )
         if proc.stdout:
             logger["save-changes"].info(f"Commit message: {message!r}")
-            subprocess.run(["git", "commit", "-m", message], check=True)
+            run(["git", "commit", "-m", message])
             logger["save-changes"].info("Pushing changes")
-            subprocess.run(["git", "push"], check=True)
+            run(["git", "push"])
         else:
             logger["save-changes"].warning("No changes to push")
     except subprocess.CalledProcessError:

--- a/src/jg/coop/cli/dev.py
+++ b/src/jg/coop/cli/dev.py
@@ -31,8 +31,10 @@ def update(pull, packages, push, stash):
         logger.info("Terminating running processes")
         python_path = sys.executable
         jg_path = f"{python_path.removesuffix('3').removesuffix('/python')}/jg"
-        subprocess.run(["pgrep", "-fl", jg_path])  # prints what's getting terminated
-        subprocess.run(["pkill", "-SIGTERM", "-f", jg_path])
+        subprocess.run(
+            ["pgrep", "-fl", jg_path], check=False
+        )  # prints what's getting terminated
+        subprocess.run(["pkill", "-SIGTERM", "-f", jg_path], check=False)
         if stash:
             logger.info("Stashing work in progress")
             subprocess.run(["git", "stash"], check=True)
@@ -47,8 +49,8 @@ def update(pull, packages, push, stash):
             subprocess.run(["npm", "update"], check=True)
             subprocess.run(["npm", "install"], check=True)
             paths = ["pyproject.toml", "uv.lock", "package-lock.json", ci_config_path]
-            subprocess.run(["git", "add"] + paths)
-            subprocess.run(["git", "commit", "-m", "update packages 📦"])
+            subprocess.run(["git", "add"] + paths, check=False)
+            subprocess.run(["git", "commit", "-m", "update packages 📦"], check=False)
         else:
             logger.info("Installing packages")
             subprocess.run(["uv", "install"], check=True)
@@ -176,7 +178,9 @@ def save_changes(paths, message, build_url, skip_ci):
             subprocess.run(["git", "add", "-A", str(path)], check=True)
 
         proc = subprocess.run(
-            ["git", "diff", "--name-only", "--cached"], stdout=subprocess.PIPE
+            ["git", "diff", "--name-only", "--cached"],
+            stdout=subprocess.PIPE,
+            check=False,
         )
         if proc.stdout:
             logger["save-changes"].info(f"Commit message: {message!r}")

--- a/src/jg/coop/cli/screenshots.py
+++ b/src/jg/coop/cli/screenshots.py
@@ -227,17 +227,17 @@ def is_expired_path(path):
 
 
 def is_overridden_screenshot(screenshot):
-    _url, path = screenshot
+    _, path = screenshot
     return (SCREENSHOTS_OVERRIDES_DIR / Path(path).name).exists()
 
 
 def is_existing_screenshot(screenshot):
-    _url, path = screenshot
+    _, path = screenshot
     return Path(path).exists()
 
 
 def is_yt_screenshot(screenshot):
-    url, _path = screenshot
+    url, _ = screenshot
     try:
         return bool(parse_youtube_id(url))
     except ValueError:
@@ -245,7 +245,7 @@ def is_yt_screenshot(screenshot):
 
 
 def is_fb_screenshot(screenshot):
-    url, _path = screenshot
+    url, _ = screenshot
     return bool(FACEBOOK_URL_RE.search(url))
 
 

--- a/src/jg/coop/cli/screenshots.py
+++ b/src/jg/coop/cli/screenshots.py
@@ -227,17 +227,17 @@ def is_expired_path(path):
 
 
 def is_overridden_screenshot(screenshot):
-    url, path = screenshot
+    _url, path = screenshot
     return (SCREENSHOTS_OVERRIDES_DIR / Path(path).name).exists()
 
 
 def is_existing_screenshot(screenshot):
-    url, path = screenshot
+    _url, path = screenshot
     return Path(path).exists()
 
 
 def is_yt_screenshot(screenshot):
-    url, path = screenshot
+    url, _path = screenshot
     try:
         return bool(parse_youtube_id(url))
     except ValueError:
@@ -245,7 +245,7 @@ def is_yt_screenshot(screenshot):
 
 
 def is_fb_screenshot(screenshot):
-    url, path = screenshot
+    url, _path = screenshot
     return bool(FACEBOOK_URL_RE.search(url))
 
 

--- a/src/jg/coop/lib/cache.py
+++ b/src/jg/coop/lib/cache.py
@@ -43,7 +43,7 @@ def close_cache() -> None:
 
 
 def cache(
-    expire: float | int | timedelta | None = None,
+    expire: float | timedelta | None = None,
     tag: str | None = None,
     ignore: tuple[int | str] = (),
 ) -> Callable:

--- a/src/jg/coop/lib/discord_club.py
+++ b/src/jg/coop/lib/discord_club.py
@@ -229,7 +229,9 @@ def is_message_older_than(message: "discord.Message | ClubMessage", date: date) 
 
 
 def is_message_over_period_ago(
-    message: "discord.Message | ClubMessage", period: timedelta, today: date = None
+    message: "discord.Message | ClubMessage",
+    period: timedelta,
+    today: date | None = None,
 ) -> bool:
     today = today or date.today()
     ago = today - period
@@ -269,7 +271,7 @@ async def add_reactions(
                 f"Message #{message.jump_url} reached maximum number of reactions!"
             )
         else:
-            raise e
+            raise
 
 
 def get_missing_reactions(reactions: discord.Reaction, emojis: set[str]) -> set[str]:

--- a/src/jg/coop/lib/discord_task.py
+++ b/src/jg/coop/lib/discord_task.py
@@ -46,7 +46,7 @@ def run(task_fn: Callable[..., Awaitable], *args, **kwargs) -> None:
 
             async def on_error(self, event, *args, **kwargs):
                 logger.debug("Got an error")
-                exc_type, exc_value, tb = sys.exc_info()
+                _exc_type, exc_value, _tb = sys.exc_info()
                 exc_queue.put(exc_value)
 
         logger.debug("Starting")

--- a/src/jg/coop/lib/images.py
+++ b/src/jg/coop/lib/images.py
@@ -98,7 +98,7 @@ def render_template(
     height: int,
     template_name: str,
     context: dict[str, Any],
-    filters: dict[str, Callable] = None,
+    filters: dict[str, Callable] | None = None,
 ) -> bytes:
     logger.info(f"Rendering {width}x{height} {template_name}")
     if not list(CACHE_DIR.glob("*.css")):
@@ -253,7 +253,7 @@ def create_fallback_image(
     font = ImageFont.truetype(font_path, size_px - (padding * 2))
 
     logger.debug(f"Centering text for {initial}")
-    _, _, box_width, box_height = draw.textbbox(xy=(0, 0), text=initial, font=font)
+    _, _, _box_width, box_height = draw.textbbox(xy=(0, 0), text=initial, font=font)
     text_width, text_height = font.getmask(initial).size
     x_text = (size_px - text_width) / 2
     y_text = ((size_px - box_height) / 2) - ((box_height - text_height) / 2)

--- a/src/jg/coop/lib/memberful.py
+++ b/src/jg/coop/lib/memberful.py
@@ -47,7 +47,7 @@ class MemberfulAPI:
 
     def __init__(
         self,
-        api_key: str = None,
+        api_key: str | None = None,
         user_agent: str | None = None,
     ):
         self.api_key = api_key or MEMBERFUL_API_KEY
@@ -73,7 +73,9 @@ class MemberfulAPI:
         logger.debug("Sending a mutation")
         return self.client.execute(gql(mutation), variable_values=variable_values)
 
-    def get_nodes(self, query: str, variable_values: dict = None) -> Generator[dict]:
+    def get_nodes(
+        self, query: str, variable_values: dict | None = None
+    ) -> Generator[dict]:
         if match := COLLECTION_NAME_RE.search(query):
             collection_name = match.group("collection_name")
         else:
@@ -86,10 +88,12 @@ class MemberfulAPI:
             for edge in result[collection_name]["edges"]:
                 yield edge["node"]
 
-    def get(self, query: str, variable_values: dict = None) -> list[dict]:
+    def get(self, query: str, variable_values: dict | None = None) -> list[dict]:
         return self._execute_query(query, variable_values)
 
-    def _query(self, query: str, get_page_info: Callable, variable_values: dict = None):
+    def _query(
+        self, query: str, get_page_info: Callable, variable_values: dict | None = None
+    ):
         variable_values = variable_values or {}
         cursor = ""
         n = 0
@@ -125,8 +129,8 @@ class MemberfulAuthToken:
 class MemberfulCSV:
     def __init__(
         self,
-        email: str = None,
-        password: str = None,
+        email: str | None = None,
+        password: str | None = None,
         user_agent: str | None = None,
     ):
         self.email = email or MEMBERFUL_EMAIL

--- a/src/jg/coop/models/base.py
+++ b/src/jg/coop/models/base.py
@@ -3,7 +3,7 @@ import hashlib
 import json
 import pickle
 import sqlite3
-from collections.abc import Iterable, Set
+from collections.abc import Iterable, Set as AbstractSet
 from enum import Enum
 from functools import cache, wraps
 from pathlib import Path
@@ -77,7 +77,7 @@ class JSONField(BaseJSONField):
 
 def json_dumps(value):
     def default(o):
-        if isinstance(o, Set):
+        if isinstance(o, AbstractSet):
             return list(o)
         try:
             return o.isoformat()

--- a/src/jg/coop/models/event.py
+++ b/src/jg/coop/models/event.py
@@ -311,7 +311,7 @@ class Event(BaseModel):
         )
 
     @classmethod
-    def featured_listing(cls, now: datetime = None) -> list[Self]:
+    def featured_listing(cls, now: datetime | None = None) -> list[Self]:
         return list(
             itertools.chain(
                 cls.planned_listing(now=now).limit(1),

--- a/src/jg/coop/models/exchange_rate.py
+++ b/src/jg/coop/models/exchange_rate.py
@@ -10,9 +10,9 @@ class ExchangeRate(BaseModel):
     rate = DecimalField()
 
     @classmethod
-    def in_currency(cls, amount_czk: Decimal | int | float, currency: str) -> Decimal:
+    def in_currency(cls, amount_czk: Decimal | float, currency: str) -> Decimal:
         return int(amount_czk / ExchangeRate.get(code=currency.upper()).rate)
 
     @classmethod
-    def from_currency(cls, amount: Decimal | int | float, currency: str) -> Decimal:
+    def from_currency(cls, amount: Decimal | float, currency: str) -> Decimal:
         return int(amount * ExchangeRate.get(code=currency.upper()).rate)

--- a/src/jg/coop/models/job.py
+++ b/src/jg/coop/models/job.py
@@ -466,19 +466,17 @@ class ListedJob(BaseModel):
 
     def to_czechitas_api(self) -> dict[str, str | int | datetime | None]:
         return dict(
-            **{
-                "title": self.title,
-                "company_name": self.company_name,
-                "url": self.url,
-                "remote": self.remote,
-                "first_seen_at": datetime.combine(
-                    self.posted_on, time(0, 0)
-                ),  # datetime for backwards compatibility
-                "last_seen_at": None,  # not relevant anymore, equals to present moment
-                "lang": self.lang,
-                "juniority_score": None,  # won't expose publicly anymore
-                "source": None,  # use external IDs instead
-            },
+            title=self.title,
+            company_name=self.company_name,
+            url=self.url,
+            remote=self.remote,
+            first_seen_at=datetime.combine(
+                self.posted_on, time(0, 0)
+            ),  # datetime for backwards compatibility
+            last_seen_at=None,  # not relevant anymore, equals to present moment
+            lang=self.lang,
+            juniority_score=None,  # won't expose publicly anymore
+            source=None,  # use external IDs instead
             **{
                 f"external_ids_{i}": value
                 for i, value in columns(  # renamed elsewhere, but keeping backwards compatible
@@ -497,9 +495,7 @@ class ListedJob(BaseModel):
                 f"employment_types_{i}": value
                 for i, value in columns(self.employment_types, 10)
             },
-            **{
-                "description_html": self.description_html,
-            },
+            description_html=self.description_html,
         )
 
 

--- a/src/jg/coop/models/partner.py
+++ b/src/jg/coop/models/partner.py
@@ -24,7 +24,6 @@ class Partner(BaseModel):
     start_on = DateField()
     is_free = BooleanField(default=True)
     note = TextField()
-    role_id = IntegerField(null=True)
 
     @property
     def utm_campaign(self) -> Literal["partnership"]:

--- a/src/jg/coop/sync/club_content/crawler.py
+++ b/src/jg/coop/sync/club_content/crawler.py
@@ -240,7 +240,7 @@ async def fetch_members_reacting_by_pin(
 
 
 def get_history_after(
-    history_since: timedelta | None, now: datetime = None
+    history_since: timedelta | None, now: datetime | None = None
 ) -> datetime:
     if now:
         if now.tzinfo is None:

--- a/src/jg/coop/sync/course_providers.py
+++ b/src/jg/coop/sync/course_providers.py
@@ -148,7 +148,7 @@ def compile_page_title(name: str) -> str:
 
 
 @raise_if_too_long
-def compile_page_description(name: str, extra_questions: list = None) -> str:
+def compile_page_description(name: str, extra_questions: list | None = None) -> str:
     questions = [
         f"Vyplatí se kurzy programování u {name}?",
         "Co říkají absolventi?",
@@ -160,7 +160,7 @@ def compile_page_description(name: str, extra_questions: list = None) -> str:
 
 
 @raise_if_too_long
-def compile_page_lead(name: str, extra_questions: list = None) -> str:
+def compile_page_lead(name: str, extra_questions: list | None = None) -> str:
     questions = [
         f"Vyplatí se {name}?",
         "Hledáš někoho, kdo s tím má zkušenosti?",

--- a/src/jg/coop/sync/jobs_scraped/__init__.py
+++ b/src/jg/coop/sync/jobs_scraped/__init__.py
@@ -62,9 +62,8 @@ async def main():
         try:
             li_items = list(map(transform_linkedin_item, raw_li_items))
             items = itertools.chain(items, li_items)
-        except Exception as e:
-            logger.error("Failed to scrape LinkedIn!")
-            logger.exception(e)
+        except Exception:
+            logger.exception("Failed to scrape LinkedIn!")
 
     logger.info(f"Pipelines:\n{pformat(PIPELINES)}")
     pipelines = [

--- a/src/jg/coop/sync/meetups.py
+++ b/src/jg/coop/sync/meetups.py
@@ -34,6 +34,8 @@ from jg.coop.models.meetup import Meetup
 
 YAML_PATH = Path("src/jg/coop/data/meetups.yml")
 
+PRAGUE_TZ = ZoneInfo("Europe/Prague")
+
 
 logger = loggers.from_path(__file__)
 
@@ -254,7 +256,7 @@ async def sync_meetups(client: ClubClient, instructions: list[PostingInstruction
 
 
 def format_time(
-    starts_at: datetime, ends_at: datetime, tz: ZoneInfo = ZoneInfo("Europe/Prague")
+    starts_at: datetime, ends_at: datetime, tz: ZoneInfo = PRAGUE_TZ
 ) -> str:
     starts_at = starts_at.astimezone(tz)
     ends_at = ends_at.astimezone(tz)

--- a/src/jg/coop/sync/members/__init__.py
+++ b/src/jg/coop/sync/members/__init__.py
@@ -226,7 +226,7 @@ async def report_trespassing_members(client: ClubClient, members_ids: list[int])
 
 
 def get_active_subscription(
-    subscriptions: list[SubscriptionEntity], today: date = None
+    subscriptions: list[SubscriptionEntity], today: date | None = None
 ) -> SubscriptionEntity:
     today = today or date.today()
 

--- a/src/jg/coop/sync/newsletter/summary.py
+++ b/src/jg/coop/sync/newsletter/summary.py
@@ -250,7 +250,7 @@ async def summarize_club(today: date, correction_attempts: int) -> Summary:
 def to_feed(
     messages: list[ClubMessage],
     channel_mapping: dict[int, str],
-    threads_only_channels: list[int] = None,
+    threads_only_channels: list[int] | None = None,
 ) -> str:
     docs = []
     for channel_id, channel_messages in groupby(messages, key=attrgetter("channel_id")):

--- a/src/jg/coop/sync/organizations/__init__.py
+++ b/src/jg/coop/sync/organizations/__init__.py
@@ -352,13 +352,13 @@ def prepare_tiers(
 
 
 def get_start_on(periods: list[tuple[str, str | None]]) -> date:
-    first_period_start = sorted(periods)[0][0]
+    first_period_start = min(periods)[0]
     year, month = map(int, first_period_start.split("-"))
     return date(year, month, 1)
 
 
 def get_renews_on(periods: list[tuple[str, str | None]], today: date) -> bool:
-    current_period = sorted(periods, reverse=True)[0]
+    current_period = max(periods)
     period_start, period_end = current_period
 
     if period_end:

--- a/src/jg/coop/sync/roles.py
+++ b/src/jg/coop/sync/roles.py
@@ -336,18 +336,20 @@ async def apply_changes(client: ClubClient, changes):
             changes_by_members.setdefault(member_id, {"add": [], "remove": []})
             changes_by_members[member_id][op].append(role_id)
 
-    for member_id, changes in changes_by_members.items():
+    for member_id, member_changes in changes_by_members.items():
         discord_member = await client.club_guild.fetch_member(member_id)
-        if changes["add"]:
-            discord_roles = [all_discord_roles[role_id] for role_id in changes["add"]]
+        if member_changes["add"]:
+            discord_roles = [
+                all_discord_roles[role_id] for role_id in member_changes["add"]
+            ]
             logger.debug(
                 f"{discord_member.display_name}: adding {repr_roles(discord_roles)}"
             )
             with mutating_discord(discord_member) as proxy:
                 await proxy.add_roles(*discord_roles)
-        if changes["remove"]:
+        if member_changes["remove"]:
             discord_roles = [
-                all_discord_roles[role_id] for role_id in changes["remove"]
+                all_discord_roles[role_id] for role_id in member_changes["remove"]
             ]
             logger.debug(
                 f"{discord_member.display_name}: removing {repr_roles(discord_roles)}"

--- a/src/jg/coop/sync/tips.py
+++ b/src/jg/coop/sync/tips.py
@@ -68,7 +68,7 @@ def load_tips(tips_path: Path, roles: dict[str, int] | None = None):
         )
 
 
-def get_edit_url(path: Path, cwd: Path = None) -> str:
+def get_edit_url(path: Path, cwd: Path | None = None) -> str:
     cwd = cwd or Path.cwd()
     path = path.absolute().relative_to(cwd)
     return f"https://github.com/juniorguru/junior.guru/blob/main/{path}"

--- a/src/jg/coop/sync/transactions/__init__.py
+++ b/src/jg/coop/sync/transactions/__init__.py
@@ -135,7 +135,7 @@ def main(
         )
     except requests.HTTPError as e:
         logger.error(f"FioBank API error: {e.response.text}")
-        raise e
+        raise
     except requests.ConnectionError:
         logger.error("FioBank API connection error!")
         transactions = []


### PR DESCRIPTION
## Motivation

Final step of the incremental Ruff rollout from #1690. With all the individual rules now adopted (#1698–#1715), this replaces the long explicit `select` list with a config that **extends ruff 0.16's defaults** instead of re-declaring them.

## The config change

```toml
[tool.ruff.lint]
extend-select = ["C420", "E4", "E7", "E9", "FURB110", "I", "PLC0207", "PLC1802", "SIM910"]
ignore = ["ASYNC210", "ASYNC221", "ASYNC251", "BLE001", "DTZ", "RUF012"]
```

Instead of `select = [27 rules]`.

**Why these specific entries?** I verified rule-by-rule which of the previously-selected rules ruff 0.16 already enables by default. Most do (`C401/C403/C408/C413`, `FURB167`, `RUF015/RUF100`, `SIM102/103/118`, `UP006/011/017/034/035/043/047`, `F`, …). The ones that are **not** in ruff's default set stay listed so they keep being enforced: `C420`, `FURB110`, `PLC0207`, `PLC1802`, `SIM910` — plus the `E4/E7/E9` pycodestyle groups and isort (`I`) the project has always used. Dropping to a bare `extend-select = ["I"]` would have silently disabled `E7` (e.g. the `== True` / bare-except checks) and those five rules.

**The `ignore` list** matches the families #1690 deliberately opted out of, which ruff's defaults would otherwise re-activate:
- `DTZ` — naive datetimes/dates are used deliberately (peewee storage, date-only logic)
- `BLE001` — blind `except Exception` is an intentional resilience pattern in sync scripts
- `RUF012` — mutable class defaults used as config/data holders
- `ASYNC210/221/251` — blocking calls in async setup/sync code are acceptable here

## Code fixes for the newly-enabled default rules

Adopting the full default set surfaced a last batch of violations, all fixed here:

- **`RUF013`** — add `| None` to parameters that default to `None` (15 sites).
- **`PYI041`** — drop redundant `int` from `int | float` unions.
- **`RUF059`** — use `_` for unused unpacked values.
- **`PLW1510`** — pass explicit `check=False` to `subprocess.run` calls in `cli/dev.py` (preserving the existing no-raise behavior).
- **`PIE804`** — pass dict-literal kwargs directly instead of `**{...}` (keeping the explanatory field comments).
- **`PIE794`** — remove a duplicate model field definition (`partner.py`).
- **`PYI025`** — alias `collections.abc.Set` as `AbstractSet`.
- **`FURB192`** — use `min()` / `max()` instead of `sorted(...)[0]`.
- **`TRY201` / `TRY401`** — simplify a bare re-raise and a redundant `logging.exception` call.
- **`PLR1704`** — rename a loop variable shadowing a function argument (`roles.py`).
- **`B008`** — read the `ZoneInfo` default from a module-level `PRAGUE_TZ` singleton (`meetups.py`).

All behavior-preserving.

## Testing

- `uv run ruff check` → clean
- `uv run ruff format --check` → clean
- `uv run pytest` → **1114 passed, 1 skipped** (no regressions)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WpQu1qR3mFeNPFnbvowGf9)_