### PR TITLE
Simplify Ruff config to just extend the defaults

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,7 +88,11 @@ asyncio_default_fixture_loop_scope = "function"
 target-version = "py313"
 
 [tool.ruff.lint]
-extend-select = ["C420", "E4", "E7", "E9", "FURB110", "I", "PLC0207", "PLC1802", "SIM910"]
+# Rely on Ruff's default rule set, plus isort ("I"). The ignored families
+# clash with intentional patterns here: DTZ (deliberately naive datetimes),
+# BLE001 (broad excepts in sync scripts), RUF012 (mutable class defaults used
+# as config), ASYNC210/221/251 (blocking calls in async setup code).
+extend-select = ["I"]
 ignore = ["ASYNC210", "ASYNC221", "ASYNC251", "BLE001", "DTZ", "RUF012"]
 
 [tool.ruff.lint.isort]

--- a/src/jg/coop/models/candidate.py
+++ b/src/jg/coop/models/candidate.py
@@ -297,15 +297,15 @@ class Candidate(BaseModel):
 
     @classmethod
     def count_ready(cls) -> int:
-        return cls.select().where(cls.is_ready == True).count()  # noqa: E712
+        return cls.select().where(cls.is_ready == True).count()
 
     @classmethod
     def count_members(cls) -> int:
-        return cls.select().where(cls.is_member == True).count()  # noqa: E712
+        return cls.select().where(cls.is_member == True).count()
 
     @classmethod
     def count_feminine(cls) -> int:
-        return cls.select().where(cls.has_feminine_name == True).count()  # noqa: E712
+        return cls.select().where(cls.has_feminine_name == True).count()
 
     @classmethod
     def listing(cls) -> Iterable[Self]:
@@ -317,13 +317,11 @@ class Candidate(BaseModel):
     def promo_listing(cls, limit: int = 4) -> Iterable[Self]:
         first_half = limit // 2
         yield from (
-            cls.listing()
-            .where(cls.has_feminine_name == True)  # noqa: E712
-            .limit(first_half)
+            cls.listing().where(cls.has_feminine_name == True).limit(first_half)
         )
         yield from (
             cls.listing()
-            .where(cls.has_feminine_name == False)  # noqa: E712
+            .where(cls.has_feminine_name == False)
             .limit(limit - first_half)
         )
 
@@ -333,8 +331,8 @@ class Candidate(BaseModel):
             cls.listing()
             .join(ClubUser)
             .where(
-                cls.is_member == True,  # noqa: E712
-                cls.is_ready == False,  # noqa: E712
+                cls.is_member == True,
+                cls.is_ready == False,
                 cls.report_url.is_null(False),
                 ClubUser.dm_channel_id.is_null(False),
             )

--- a/src/jg/coop/models/club.py
+++ b/src/jg/coop/models/club.py
@@ -108,9 +108,9 @@ class ClubUser(BaseModel):
 
     @property
     def list_public_messages(self) -> Iterable["ClubMessage"]:
-        return self.list_messages.where(
-            ClubMessage.is_private == False  # noqa: E712
-        ).order_by(ClubMessage.created_at.desc())
+        return self.list_messages.where(ClubMessage.is_private == False).order_by(
+            ClubMessage.created_at.desc()
+        )
 
     @property
     def intro_thread_id(self) -> int | None:
@@ -196,11 +196,7 @@ class ClubUser(BaseModel):
 
     @classmethod
     def feminine_names_count(cls) -> int:
-        return (
-            cls.members_listing()
-            .where(cls.has_feminine_name == True)  # noqa: E712
-            .count()
-        )
+        return cls.members_listing().where(cls.has_feminine_name == True).count()
 
     @classmethod
     def subscription_types_breakdown(cls) -> dict[str, int]:
@@ -211,12 +207,9 @@ class ClubUser(BaseModel):
                 fn.count(cls.id).alias("count"),
             )
             .where(
-                cls.is_bot == False,  # noqa: E712
-                cls.is_member == True,  # noqa: E712
-                (
-                    (cls.is_trespassing == False)  # noqa: E712
-                    | cls.is_trespassing.is_null()
-                ),
+                cls.is_bot == False,
+                cls.is_member == True,
+                ((cls.is_trespassing == False) | cls.is_trespassing.is_null()),
             )
             .group_by(cls.subscription_type)
             .order_by(cls.subscription_type)
@@ -236,12 +229,9 @@ class ClubUser(BaseModel):
     @classmethod
     def members_listing(cls, shuffle=False) -> Iterable[Self]:
         members = cls.listing().where(
-            cls.is_bot == False,  # noqa: E712
-            cls.is_member == True,  # noqa: E712
-            (
-                (cls.is_trespassing == False)  # noqa: E712
-                | cls.is_trespassing.is_null()
-            ),
+            cls.is_bot == False,
+            cls.is_member == True,
+            ((cls.is_trespassing == False) | cls.is_trespassing.is_null()),
         )
         if shuffle:
             members = members.order_by(fn.random())
@@ -332,19 +322,15 @@ class ClubMessage(BaseModel):
         messages = (
             cls.select()
             .where(cls.created_month == f"{date:%Y-%m}")
-            .where(cls.author_is_bot == False)  # noqa: E712
-            .where(cls.is_private == False)  # noqa: E712
+            .where(cls.author_is_bot == False)
+            .where(cls.is_private == False)
             .where(cls.channel_id.not_in(STATS_EXCLUDE_CHANNELS))
         )
         return sum(message.content_size for message in messages)
 
     @classmethod
     def listing(cls) -> Iterable[Self]:
-        return (
-            cls.select()
-            .where(cls.is_private == False)  # noqa: E712
-            .order_by(cls.created_at)
-        )
+        return cls.select().where(cls.is_private == False).order_by(cls.created_at)
 
     @classmethod
     def pinning_listing(cls) -> Iterable[Self]:
@@ -377,7 +363,7 @@ class ClubMessage(BaseModel):
         else:
             query = query.where(cls.channel_id == channel_id)
         if by_bot:
-            query = query.where(cls.author_is_bot == True)  # noqa: E712
+            query = query.where(cls.author_is_bot == True)
         if starting_emoji:
             query = query.where(cls.content_starting_emoji == starting_emoji)
         if since_at:
@@ -416,7 +402,7 @@ class ClubMessage(BaseModel):
             .order_by(cls.created_at.desc())
         )
         if skip_guide:
-            query = query.having(fn.max(cls.is_forum_guide == False))  # noqa: E712
+            query = query.having(fn.max(cls.is_forum_guide == False))
         return query
 
     @classmethod
@@ -430,8 +416,8 @@ class ClubMessage(BaseModel):
             cls.select()
             .where(
                 cls.channel_id.in_([message.channel_id for message in threads]),
-                cls.is_private == False,  # noqa: E712
-                cls.author_is_bot == False,  # noqa: E712
+                cls.is_private == False,
+                cls.author_is_bot == False,
                 cls.type.in_(["default", "reply"]),
                 cls.created_at >= datetime.combine(since_on, datetime.min.time()),
             )
@@ -445,7 +431,7 @@ class ClubMessage(BaseModel):
         return (
             cls.forum_listing(channel_id, skip_guide=False)
             .where(
-                cls.is_forum_guide == True,  # noqa: E712
+                cls.is_forum_guide == True,
             )
             .first()
         )
@@ -462,8 +448,8 @@ class ClubMessage(BaseModel):
         return (
             cls.select()
             .where(
-                cls.is_private == False,  # noqa: E712
-                cls.author_is_bot == False,  # noqa: E712
+                cls.is_private == False,
+                cls.author_is_bot == False,
                 cls.type.in_(["default", "reply"]),
                 ClubMessage.parent_channel_id.not_in(exclude_channels),
                 (
@@ -481,7 +467,7 @@ class ClubMessage(BaseModel):
         return (
             cls.select()
             .where(
-                cls.is_private == False,  # noqa: E712
+                cls.is_private == False,
                 ClubMessage.parent_channel_id.not_in(UPVOTES_EXCLUDE_CHANNELS),
                 cls.created_at >= datetime.combine(since_on, datetime.min.time()),
             )
@@ -501,7 +487,7 @@ class ClubMessage(BaseModel):
                 cls.parent_channel_name,
             )
             .where(
-                cls.is_private == False,  # noqa: E712
+                cls.is_private == False,
                 ClubMessage.parent_channel_id.not_in(UPVOTES_EXCLUDE_CHANNELS),
                 cls.created_at >= datetime.combine(since_on, datetime.min.time()),
             )
@@ -529,7 +515,7 @@ class ClubMessage(BaseModel):
         query = (
             cls.select()
             .where(
-                cls.author_is_bot == True,  # noqa: E712
+                cls.author_is_bot == True,
                 cls.channel_id == channel_id,
             )
             .order_by(cls.created_at.desc())

--- a/src/jg/coop/models/event.py
+++ b/src/jg/coop/models/event.py
@@ -204,11 +204,7 @@ class Event(BaseModel):
 
     @classmethod
     def list_speaking_members(cls):
-        return (
-            ClubUser.select()
-            .where(ClubUser.is_member == True)  # noqa: E712
-            .join(EventSpeaking)
-        )
+        return ClubUser.select().where(ClubUser.is_member == True).join(EventSpeaking)
 
     @classmethod
     def listing(cls):
@@ -345,7 +341,7 @@ class EventSpeaking(BaseModel):
             cls.listing(from_date, to_date)
             .switch(cls)
             .join(ClubUser)
-            .where(ClubUser.has_feminine_name == True)  # noqa: E712
+            .where(ClubUser.has_feminine_name == True)
         )
 
     @classmethod

--- a/src/jg/coop/models/job.py
+++ b/src/jg/coop/models/job.py
@@ -415,7 +415,7 @@ class ListedJob(BaseModel):
 
     @classmethod
     def remote_listing(cls) -> Iterable[Self]:
-        return cls.listing().where(cls.remote == True)  # noqa: E712
+        return cls.listing().where(cls.remote == True)
 
     @classmethod
     def tags_listing(cls, tags: Iterable[str]) -> Iterable[Self]:

--- a/src/jg/coop/models/page.py
+++ b/src/jg/coop/models/page.py
@@ -76,7 +76,7 @@ class Page(BaseModel):
             .from_(cls, stages)
             .where(
                 cls.nav_name.is_null(False),
-                cls.noindex == False,  # noqa: E712
+                cls.noindex == False,
                 stages.c.value == slug,
             )
             .order_by(cls.nav_sort_key)
@@ -89,7 +89,7 @@ class Page(BaseModel):
             cls.listing()
             .from_(cls, stages)
             .where(
-                cls.noindex == True,  # noqa: E712
+                cls.noindex == True,
                 stages.c.value == slug,
             )
             .order_by(cls.title)

--- a/src/jg/coop/models/partner.py
+++ b/src/jg/coop/models/partner.py
@@ -43,7 +43,7 @@ class Partner(BaseModel):
 
     @classmethod
     def free_listing(cls) -> Iterable[Self]:
-        return cls.listing().where(cls.is_free == True)  # noqa: E712
+        return cls.listing().where(cls.is_free == True)
 
     @classmethod
     def count(cls) -> int:

--- a/src/jg/coop/models/podcast.py
+++ b/src/jg/coop/models/podcast.py
@@ -114,7 +114,7 @@ class PodcastEpisode(BaseModel):
     @classmethod
     def women_listing(cls, from_date, to_date):
         return cls.guests_listing(from_date, to_date).where(
-            cls.guest_has_feminine_name == True  # noqa: E712
+            cls.guest_has_feminine_name == True
         )
 
     @classmethod

--- a/src/jg/coop/models/sponsor.py
+++ b/src/jg/coop/models/sponsor.py
@@ -153,15 +153,11 @@ class GitHubSponsor(BaseModel):
 
     @classmethod
     def listing(cls) -> Iterable[Self]:
-        return (
-            cls.select().where(cls.is_active == True).order_by(cls.slug)  # noqa: E712
-        )
+        return cls.select().where(cls.is_active == True).order_by(cls.slug)
 
     @classmethod
     def past_listing(cls) -> Iterable[Self]:
-        return (
-            cls.select().where(cls.is_active == False).order_by(cls.slug)  # noqa: E712
-        )
+        return cls.select().where(cls.is_active == False).order_by(cls.slug)
 
     @classmethod
     def count(cls) -> int:

--- a/src/jg/coop/sync/club_content/store.py
+++ b/src/jg/coop/sync/club_content/store.py
@@ -182,7 +182,7 @@ def store_dm_channel(channel: DMChannel) -> None:
     )
     rows_count = (
         ClubUser.update({ClubUser.dm_channel_id: channel.id})
-        .where(ClubUser.id == member.id, ClubUser.is_member == True)  # noqa: E712
+        .where(ClubUser.id == member.id, ClubUser.is_member == True)
         .execute()
     )
     if rows_count != 1:


### PR DESCRIPTION
## Motivation

Follow-up to #1716. That PR kept several rules explicit (`E4/E7/E9` + `C420/FURB110/PLC0207/PLC1802/SIM910`) to avoid dropping enforcement. Per feedback, the preference is to just trust ruff's defaults and not maintain a hand-picked rule list.

## What changed

```toml
[tool.ruff.lint]
extend-select = ["I"]
ignore = ["ASYNC210", "ASYNC221", "ASYNC251", "BLE001", "DTZ", "RUF012"]
```

- The `extend-select` list collapses to just `"I"` (isort). Everything else comes from ruff's default rule set.
- The `ignore` list stays — it's what makes the defaults workable here, and it's family-level intent rather than cherry-picked enforcement: `DTZ` (deliberately naive datetimes), `BLE001` (broad excepts in sync scripts), `RUF012` (mutable class defaults used as config), `ASYNC210/221/251` (blocking calls in async setup). Without it, `ruff check` fails immediately (`DTZ` alone is 100+ hits). A short comment above the config records why.

### Note on what this drops

ruff 0.16's default set no longer includes the `E4/E7/E9` pycodestyle groups (nor `C420/FURB110/PLC0207/PLC1802/SIM910`), so those are no longer enforced going forward. The code they cleaned up stays clean; enforcement now simply follows ruff's defaults.

Because `E712` is no longer enabled, the `# noqa: E712` directives on the intentional peewee `field == True` / `== False` comparisons became unused — `ruff --fix` removed them (38 of them). The comparisons themselves are unchanged (peewee needs `== True`, not `is True`).

## Testing

- `uv run ruff check` → clean
- `uv run ruff format --check` → clean
- `uv run pytest` → **1114 passed, 1 skipped** (no regressions)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WpQu1qR3mFeNPFnbvowGf9)_