### PR TITLE
Make datazurnal RSS fetch resilient to transient errors

### DIFF
--- a/src/jg/coop/sync/datazurnal.py
+++ b/src/jg/coop/sync/datazurnal.py
@@ -1,7 +1,15 @@
+import logging
+
 import click
 import feedparser
 import httpx
 from discord.abc import GuildChannel
+from tenacity import (
+    before_sleep_log,
+    retry,
+    retry_if_exception_type,
+    stop_after_attempt,
+)
 
 from jg.coop.cli.sync import main as cli
 from jg.coop.lib import discord_task, loggers, mutations
@@ -25,8 +33,11 @@ EMOJI = "📰"
 @db.connection_context()
 def main(channel_id: int, rss_url: str):
     logger.info(f"Reading RSS: {rss_url}")
-    response = httpx.get(rss_url)
-    response.raise_for_status()
+    try:
+        response = fetch_rss(rss_url)
+    except httpx.HTTPError as e:
+        logger.warning(f"Failed to fetch RSS {rss_url}: {e}")
+        return
     if not (articles := feedparser.parse(response.content).entries):
         logger.warning("No articles found in RSS feed")
         return
@@ -47,6 +58,18 @@ def main(channel_id: int, rss_url: str):
 
     logger.info("Posting new article")
     discord_task.run(post, channel_id, latest.title, latest.link, mins)
+
+
+@retry(
+    retry=retry_if_exception_type(httpx.HTTPError),
+    stop=stop_after_attempt(3),
+    reraise=True,
+    before_sleep=before_sleep_log(logger, logging.WARNING),
+)
+def fetch_rss(rss_url: str) -> httpx.Response:
+    response = httpx.get(rss_url)
+    response.raise_for_status()
+    return response
 
 
 @mutations.mutates_discord()


### PR DESCRIPTION
## What & why

The `nightly` workflow failed (pipeline 15506, job `sync-2` shard 3) because the `datazurnal` scraper crashed fetching `https://samizdat.cz/rss.xml`:

```
httpx.HTTPStatusError: Server error '526 <none>' for url 'https://samizdat.cz/rss.xml'
```

HTTP **526** is a Cloudflare "Invalid SSL Certificate" error at samizdat.cz's origin — a transient, upstream problem. But `main()` called `response.raise_for_status()` with no tolerance, so a momentary blip in one external feed took down the entire nightly sync shard.

## Change

- Extract the RSS request into a `fetch_rss()` helper decorated with `tenacity`'s `@retry` (3 attempts on `httpx.HTTPError`, warning logged before each sleep) — matching the existing retry pattern used elsewhere in the codebase (e.g. `jobs_listing.py`).
- If the request still fails after retries, `main()` logs a warning and returns cleanly instead of crashing, so a flaky upstream feed no longer fails the build.

`httpx.HTTPError` is the common base for both `raise_for_status()` status errors and transport-level errors (connect/timeout), so both are retried and tolerated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cm8FU9dFpayxLW4JRqLMh4

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cm8FU9dFpayxLW4JRqLMh4)_