### PR TITLE
Retry image downloads on HTTP status errors

### DIFF
--- a/src/jg/coop/sync/candidates.py
+++ b/src/jg/coop/sync/candidates.py
@@ -224,7 +224,7 @@ async def main(
 
 @cache(expire=timedelta(hours=1), ignore=(0,), tag="candidates-images")
 @retry(
-    retry=retry_if_exception_type(httpx.RequestError),
+    retry=retry_if_exception_type((httpx.RequestError, httpx.HTTPStatusError)),
     wait=wait_random_exponential(max=60),
     stop=stop_after_attempt(3),
     reraise=True,


### PR DESCRIPTION
## What

`download_image` in `src/jg/coop/sync/candidates.py` retried only on `httpx.RequestError`, but `response.raise_for_status()` raises `httpx.HTTPStatusError` — a sibling class under `httpx.HTTPError`, not a subclass of `RequestError`. So a transient server error slipped straight through the tenacity retry with zero attempts.

## Why

Nightly build #15546 failed in `sync-2` with a `503 Service Unavailable` on `https://juniorguru.github.io/eggtray/projects/...webp`, cascading `data-2`, `web`, `deploy-web`, `check-links`, `backup` to `not_run`. `sync-2` had passed the four prior nights — the 503 is transient, and the retry was supposed to absorb it but never engaged.

## Fix

Add `httpx.HTTPStatusError` to the retry predicate. Retrying all status errors (including 4xx) is intentionally accepted — capped at 3 attempts, so no meaningful harm.

## Scope

Audited the other `retry_if_exception_type(httpx.RequestError)` sites:
- `sync/jobs_logos.py` — already handles this correctly (retries `RequestError` plus a predicate matching retryable `HTTPStatusError` codes).
- `lib/buttondown.py` — deliberately converts `HTTPStatusError` into a domain `ButtondownError` (fail-fast on API errors); left unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_016qWkJTkty2EuuErFGi8sjM)_