### PR TITLE
Handle empty LLM responses with retry logic

### DIFF
--- a/src/jg/coop/lib/llm.py
+++ b/src/jg/coop/lib/llm.py
@@ -36,6 +36,24 @@ class LLMModel(StrEnum):
     advanced = "gpt-4.1"
 
 
+class EmptyLLMResponseError(Exception):
+    """The LLM returned an empty response, a transient issue worth retrying."""
+
+
+def is_empty_response_error(error: ValidationError) -> bool:
+    """Whether a schema validation failure is caused by an empty LLM response.
+
+    Distinguishes an empty (or whitespace-only) completion, which is a transient
+    condition worth retrying, from a genuine schema mismatch or truncated JSON.
+    """
+    return any(
+        detail["type"] == "json_invalid"
+        and isinstance(detail.get("input"), str)
+        and not detail["input"].strip()
+        for detail in error.errors()
+    )
+
+
 @lru_cache
 def get_client() -> AsyncOpenAI:
     logger.debug("Creating OpenAI client")
@@ -96,6 +114,11 @@ retry_defaults = {
     wait=wait_random_exponential(min=60, max=5 * 60),
     **retry_defaults,
 )
+@retry(
+    retry=retry_if_exception_type(EmptyLLMResponseError),
+    wait=wait_random_exponential(min=2, max=30),
+    **retry_defaults,
+)
 @cache(expire=timedelta(days=60), tag="llm")
 async def ask_llm[Schema: BaseModel](
     system_prompt: str,
@@ -128,6 +151,10 @@ async def ask_llm[Schema: BaseModel](
                     ).output_parsed
                     break
                 except ValidationError as e:
+                    if is_empty_response_error(e):
+                        raise EmptyLLMResponseError(
+                            "LLM returned an empty response"
+                        ) from e
                     if attempt == validation_attempts:
                         raise
                     logger.warning(f"Schema validation failed, attempt #{attempt}: {e}")
@@ -139,6 +166,8 @@ async def ask_llm[Schema: BaseModel](
                     # prompt_cache_retention="24h",
                 )
             ).output_text
+            if not result.strip():
+                raise EmptyLLMResponseError("LLM returned an empty response")
     return result
 
 

--- a/tests/test_lib_llm.py
+++ b/tests/test_lib_llm.py
@@ -1,0 +1,29 @@
+import pytest
+from pydantic import BaseModel, ValidationError
+
+from jg.coop.lib.llm import is_empty_response_error
+
+
+class DummySchema(BaseModel):
+    number: int
+
+
+def make_validation_error(json_text: str) -> ValidationError:
+    try:
+        DummySchema.model_validate_json(json_text)
+    except ValidationError as error:
+        return error
+    raise AssertionError("Expected a ValidationError")
+
+
+@pytest.mark.parametrize("json_text", ["", "   ", "\n\t"])
+def test_is_empty_response_error_true(json_text):
+    assert is_empty_response_error(make_validation_error(json_text)) is True
+
+
+@pytest.mark.parametrize(
+    "json_text",
+    ['{"number":', '{"number": "not an int"}', '{"other": 1}'],
+)
+def test_is_empty_response_error_false(json_text):
+    assert is_empty_response_error(make_validation_error(json_text)) is False


### PR DESCRIPTION
Distinguish empty LLM responses (transient, worth retrying) from genuine schema validation failures.

**Changes:**
- Add `EmptyLLMResponseError` exception for empty/whitespace-only completions
- Add `is_empty_response_error()` to detect empty responses in validation errors by checking for `json_invalid` errors with empty input
- Add retry decorator to `ask_llm()` with exponential backoff (2-30s) for `EmptyLLMResponseError`
- Raise `EmptyLLMResponseError` when schema validation fails due to empty input
- Raise `EmptyLLMResponseError` when final text result is empty/whitespace-only
- Add test coverage for `is_empty_response_error()` with empty and non-empty inputs

**Implementation details:**
- Detects empty responses at two points: during JSON schema validation and after text completion
- Distinguishes from truncated JSON or schema mismatches via Pydantic's `json_invalid` error type
- Separate retry strategy from rate-limit retries (60-300s) to handle transient issues faster

https://claude.ai/code/session_01VokCc6aD2iErpYLEgJXLVH