### PR TITLE
Fix CHECK constraint failure on Instagram/TikTok marketing survey answers

### DIFF
--- a/src/jg/coop/models/subscription.py
+++ b/src/jg/coop/models/subscription.py
@@ -50,6 +50,8 @@ class SubscriptionMarketingSurveyAnswer(StrEnum):
     PODCASTS = "podcasts"
     COURSES = "courses"
     YOUTUBE = "youtube"
+    INSTAGRAM = "instagram"
+    TIKTOK = "tiktok"
     FACEBOOK = "facebook"
     LINKEDIN = "linkedin"
     COURSES_SEARCH = "courses_search"


### PR DESCRIPTION
## Problem

The Memberful CSV sync repeatedly failed with:

```
CHECK constraint failed: type in ('yablko', 'friend', 'podcasts', 'courses',
'youtube', 'facebook', 'linkedin', 'courses_search', 'search', 'internet',
'llm', 'other')
```

`classify_marketing_survey_answer()` returns `"instagram"` and `"tiktok"`, but neither value was present in `SubscriptionMarketingSurveyAnswer`, the enum backing the CHECK constraint on `SubscriptionMarketingSurvey.type`. Any member whose survey answer mentioned Instagram or TikTok caused the insert to violate the constraint, aborting the sync.

The classifier's own tests already expected `instagram`/`tiktok` outputs — the enum was simply never updated to match.

## Fix

Add `INSTAGRAM = "instagram"` and `TIKTOK = "tiktok"` to `SubscriptionMarketingSurveyAnswer`.

## Testing

`uv run pytest tests/test_sync_subscriptions_csv.py` — 61 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NGWLfd6SauwP6YLD1XhWTE

---
_Generated by [Claude Code](https://claude.ai/code/session_01NGWLfd6SauwP6YLD1XhWTE)_