### PR TITLE
Log LLM response diagnostics on schema validation failure

### DIFF
--- a/src/jg/coop/lib/llm.py
+++ b/src/jg/coop/lib/llm.py
@@ -8,6 +8,7 @@ from typing import overload
 
 import tiktoken
 from openai import AsyncOpenAI, InternalServerError, RateLimitError
+from openai.types.responses import Response
 from pydantic import BaseModel, ValidationError
 from tenacity import (
     before_sleep_log,
@@ -117,20 +118,32 @@ async def ask_llm[Schema: BaseModel](
         if schema:
             for attempt in range(1, validation_attempts + 1):
                 logger.debug(f"Asking LLM with schema validation, attempt #{attempt}")
+                # Fetch the raw response so we can inspect it (status, refusal,
+                # incomplete_details) when parsing fails, instead of only seeing
+                # an opaque "invalid JSON: EOF" error. Non-2xx (rate limit, 5xx)
+                # still raises before this returns, so retries keep working.
+                raw_response = await client.responses.with_raw_response.parse(
+                    model=str(model),
+                    input=llm_input,
+                    text_format=schema,
+                    # prompt_cache_retention="24h",
+                )
+                response = Response.model_validate_json(await raw_response.text())
                 try:
-                    result = (
-                        await client.responses.parse(
-                            model=str(model),
-                            input=llm_input,
-                            text_format=schema,
-                            # prompt_cache_retention="24h",
-                        )
-                    ).output_parsed
+                    result = schema.model_validate_json(response.output_text)
                     break
                 except ValidationError as e:
+                    reason = describe_response(response)
                     if attempt == validation_attempts:
+                        logger.error(
+                            f"Schema validation failed, attempt #{attempt} (final): "
+                            f"{e}\nLLM response: {reason}"
+                        )
                         raise
-                    logger.warning(f"Schema validation failed, attempt #{attempt}: {e}")
+                    logger.warning(
+                        f"Schema validation failed, attempt #{attempt}: "
+                        f"{e}\nLLM response: {reason}"
+                    )
         else:
             result = (
                 await client.responses.create(
@@ -140,6 +153,22 @@ async def ask_llm[Schema: BaseModel](
                 )
             ).output_text
     return result
+
+
+def describe_response(response: Response) -> str:
+    parts = [f"status={response.status!r}"]
+    if response.incomplete_details:
+        parts.append(f"incomplete_reason={response.incomplete_details.reason!r}")
+    if response.error:
+        parts.append(f"error={response.error.code!r}: {response.error.message!r}")
+    for item in response.output:
+        if item.type == "message":
+            for content in item.content:
+                if content.type == "refusal":
+                    parts.append(f"refusal={content.refusal!r}")
+    text = response.output_text
+    parts.append(f"output_text={text[:500]!r} ({len(text)} chars)")
+    return ", ".join(parts)
 
 
 def count_tokens(text: str) -> int:

--- a/src/jg/coop/lib/llm.py
+++ b/src/jg/coop/lib/llm.py
@@ -49,7 +49,6 @@ async def ask_llm(
     user_prompt: str,
     model: LLMModel = LLMModel.simple,
     schema: None = None,
-    validation_attempts: int = 3,
 ) -> str: ...
 
 
@@ -59,8 +58,11 @@ async def ask_llm[Schema: BaseModel](
     user_prompt: str,
     model: LLMModel = LLMModel.simple,
     schema: type[Schema] = ...,
-    validation_attempts: int = 3,
 ) -> Schema: ...
+
+
+# How many times to re-ask the LLM when its response does not match the schema.
+VALIDATION_ATTEMPTS = 3
 
 
 retry_defaults = {
@@ -97,13 +99,17 @@ retry_defaults = {
     wait=wait_random_exponential(min=60, max=5 * 60),
     **retry_defaults,
 )
+@retry(
+    retry=retry_if_exception_type(ValidationError),
+    stop=stop_after_attempt(VALIDATION_ATTEMPTS),
+    reraise=True,
+)
 @cache(expire=timedelta(days=60), tag="llm")
 async def ask_llm[Schema: BaseModel](
     system_prompt: str,
     user_prompt: str,
     model: LLMModel = LLMModel.simple,
     schema: type[Schema] | None = None,
-    validation_attempts: int = 3,
 ) -> Schema | str:
     client = get_client()
     async with limit(4):
@@ -116,43 +122,34 @@ async def ask_llm[Schema: BaseModel](
             {"role": "user", "content": prompt(user_prompt)},
         ]
         if schema:
-            for attempt in range(1, validation_attempts + 1):
-                logger.debug(f"Asking LLM with schema validation, attempt #{attempt}")
-                # Fetch the raw response so we can inspect it (status, refusal,
-                # incomplete_details) when parsing fails, instead of only seeing
-                # an opaque "invalid JSON: EOF" error. Non-2xx (rate limit, 5xx)
-                # still raises before this returns, so retries keep working.
-                raw_response = await client.responses.with_raw_response.parse(
-                    model=str(model),
-                    input=llm_input,
-                    text_format=schema,
-                    # prompt_cache_retention="24h",
+            # Fetch the raw response so we can inspect it (status, refusal,
+            # incomplete_details) when parsing fails, instead of only seeing
+            # an opaque "invalid JSON: EOF" error. Non-2xx (rate limit, 5xx)
+            # still raises before this returns, so those retries keep working.
+            raw_response = await client.responses.with_raw_response.parse(
+                model=str(model),
+                input=llm_input,
+                text_format=schema,
+                # prompt_cache_retention="24h",
+            )
+            response = Response.model_validate_json(await raw_response.text())
+            try:
+                return schema.model_validate_json(response.output_text)
+            except ValidationError:
+                # Logged on every failed attempt, so the reason is visible right
+                # before the retry decorator re-asks or finally re-raises.
+                logger.warning(
+                    f"LLM response failed schema validation: "
+                    f"{describe_response(response)}"
                 )
-                response = Response.model_validate_json(await raw_response.text())
-                try:
-                    result = schema.model_validate_json(response.output_text)
-                    break
-                except ValidationError as e:
-                    reason = describe_response(response)
-                    if attempt == validation_attempts:
-                        logger.error(
-                            f"Schema validation failed, attempt #{attempt} (final): "
-                            f"{e}\nLLM response: {reason}"
-                        )
-                        raise
-                    logger.warning(
-                        f"Schema validation failed, attempt #{attempt}: "
-                        f"{e}\nLLM response: {reason}"
-                    )
-        else:
-            result = (
-                await client.responses.create(
-                    model=str(model),
-                    input=llm_input,
-                    # prompt_cache_retention="24h",
-                )
-            ).output_text
-    return result
+                raise
+        return (
+            await client.responses.create(
+                model=str(model),
+                input=llm_input,
+                # prompt_cache_retention="24h",
+            )
+        ).output_text
 
 
 def describe_response(response: Response) -> str:

--- a/src/jg/coop/lib/llm.py
+++ b/src/jg/coop/lib/llm.py
@@ -122,26 +122,28 @@ async def ask_llm[Schema: BaseModel](
             {"role": "user", "content": prompt(user_prompt)},
         ]
         if schema:
-            # Fetch the raw response so we can inspect it (status, refusal,
-            # incomplete_details) when parsing fails, instead of only seeing
-            # an opaque "invalid JSON: EOF" error. Non-2xx (rate limit, 5xx)
-            # still raises before this returns, so those retries keep working.
+            # Go through with_raw_response so that, when the SDK fails to parse
+            # the structured output, we still have the raw response to inspect
+            # (status, refusal, incomplete_details) instead of just an opaque
+            # "invalid JSON: EOF" error. The happy path still uses the SDK's own
+            # parsing (raw_response.parse()), so we don't reimplement it.
             raw_response = await client.responses.with_raw_response.parse(
                 model=str(model),
                 input=llm_input,
                 text_format=schema,
                 # prompt_cache_retention="24h",
             )
-            response = Response.model_validate_json(await raw_response.text())
             try:
-                return schema.model_validate_json(response.output_text)
+                return (await raw_response.parse()).output_parsed
             except ValidationError:
-                # Logged on every failed attempt, so the reason is visible right
-                # before the retry decorator re-asks or finally re-raises.
-                logger.warning(
-                    f"LLM response failed schema validation: "
-                    f"{describe_response(response)}"
-                )
+                # Best-effort diagnostic, logged before the retry decorator
+                # re-asks or finally re-raises; never mask the real error.
+                try:
+                    response = Response.model_validate_json(await raw_response.text())
+                    reason = describe_response(response)
+                except Exception as diagnostic_error:
+                    reason = f"could not describe response: {diagnostic_error}"
+                logger.warning(f"LLM response failed schema validation: {reason}")
                 raise
         return (
             await client.responses.create(

--- a/src/jg/coop/lib/llm.py
+++ b/src/jg/coop/lib/llm.py
@@ -11,6 +11,7 @@ from openai import AsyncOpenAI, InternalServerError, RateLimitError
 from openai.types.responses import Response
 from pydantic import BaseModel, ValidationError
 from tenacity import (
+    RetryCallState,
     before_sleep_log,
     retry,
     retry_if_exception,
@@ -61,8 +62,27 @@ async def ask_llm[Schema: BaseModel](
 ) -> Schema: ...
 
 
-# How many times to re-ask the LLM when its response does not match the schema.
 VALIDATION_ATTEMPTS = 3
+
+
+class LLMResponseError(Exception):
+    pass
+
+
+def is_requests_rate_limit_error(exception: RateLimitError) -> bool:
+    return exception.type == "requests" and "requests per day" not in exception.message
+
+
+def is_tokens_rate_limit_error(exception: RateLimitError) -> bool:
+    return exception.type == "tokens"
+
+
+def log_and_reraise_validation_error(retry_state: RetryCallState) -> None:
+    # Runs only after the last validation attempt, so the terminal diagnostic
+    # is logged at error level before the exception propagates.
+    exception = retry_state.outcome.exception()
+    logger.error(str(exception))
+    raise exception
 
 
 retry_defaults = {
@@ -76,12 +96,7 @@ retry_defaults = {
 @retry(
     retry=(
         retry_if_exception_type(RateLimitError)
-        & retry_if_exception(
-            lambda exception: (
-                exception.type == "requests"
-                and "requests per day" not in exception.message
-            )
-        )
+        & retry_if_exception(is_requests_rate_limit_error)
     ),
     wait=wait_random_exponential(min=1, max=60),
     **retry_defaults,
@@ -89,7 +104,7 @@ retry_defaults = {
 @retry(
     retry=(
         retry_if_exception_type(RateLimitError)
-        & retry_if_exception(lambda exception: exception.type == "tokens")
+        & retry_if_exception(is_tokens_rate_limit_error)
     ),
     wait=wait_random_exponential(min=60, max=5 * 60),
     **retry_defaults,
@@ -100,9 +115,11 @@ retry_defaults = {
     **retry_defaults,
 )
 @retry(
-    retry=retry_if_exception_type(ValidationError),
+    retry=retry_if_exception_type(LLMResponseError),
     stop=stop_after_attempt(VALIDATION_ATTEMPTS),
-    reraise=True,
+    # Warn before each further attempt; error on the final one (see callback).
+    before_sleep=before_sleep_log(logger, logging.WARNING),
+    retry_error_callback=log_and_reraise_validation_error,
 )
 @cache(expire=timedelta(days=60), tag="llm")
 async def ask_llm[Schema: BaseModel](
@@ -128,29 +145,23 @@ async def ask_llm[Schema: BaseModel](
             # "invalid JSON: EOF" error. The happy path still uses the SDK's own
             # parsing (raw_response.parse()), so we don't reimplement it.
             raw_response = await client.responses.with_raw_response.parse(
-                model=str(model),
-                input=llm_input,
-                text_format=schema,
-                # prompt_cache_retention="24h",
+                model=str(model), input=llm_input, text_format=schema
             )
             try:
                 return (await raw_response.parse()).output_parsed
-            except ValidationError:
-                # Best-effort diagnostic, logged before the retry decorator
-                # re-asks or finally re-raises; never mask the real error.
+            except ValidationError as e:
+                # Best-effort diagnostic, carried on the exception so the retry
+                # decorator can log it; never mask the real error.
                 try:
                     response = Response.model_validate_json(await raw_response.text())
                     reason = describe_response(response)
                 except Exception as diagnostic_error:
                     reason = f"could not describe response: {diagnostic_error}"
-                logger.warning(f"LLM response failed schema validation: {reason}")
-                raise
+                raise LLMResponseError(
+                    f"LLM response failed schema validation: {reason}"
+                ) from e
         return (
-            await client.responses.create(
-                model=str(model),
-                input=llm_input,
-                # prompt_cache_retention="24h",
-            )
+            await client.responses.create(model=str(model), input=llm_input)
         ).output_text
 
 

--- a/tests/test_lib_llm.py
+++ b/tests/test_lib_llm.py
@@ -1,7 +1,40 @@
+from types import SimpleNamespace
+
 import pytest
 from openai.types.responses import Response
 
-from jg.coop.lib.llm import describe_response
+from jg.coop.lib.llm import (
+    describe_response,
+    is_requests_rate_limit_error,
+    is_tokens_rate_limit_error,
+)
+
+
+@pytest.mark.parametrize(
+    "type_, message, expected",
+    [
+        ("requests", "too many requests", True),
+        ("requests", "requests per day exceeded", False),
+        ("tokens", "too many requests", False),
+    ],
+)
+def test_is_requests_rate_limit_error(type_, message, expected):
+    error = SimpleNamespace(type=type_, message=message)
+
+    assert is_requests_rate_limit_error(error) is expected
+
+
+@pytest.mark.parametrize(
+    "type_, expected",
+    [
+        ("tokens", True),
+        ("requests", False),
+    ],
+)
+def test_is_tokens_rate_limit_error(type_, expected):
+    error = SimpleNamespace(type=type_, message="")
+
+    assert is_tokens_rate_limit_error(error) is expected
 
 
 def create_response(**kwargs) -> Response:

--- a/tests/test_lib_llm.py
+++ b/tests/test_lib_llm.py
@@ -1,0 +1,74 @@
+import pytest
+from openai.types.responses import Response
+
+from jg.coop.lib.llm import describe_response
+
+
+def create_response(**kwargs) -> Response:
+    values = {
+        "id": "resp",
+        "created_at": 0,
+        "model": "gpt-4.1",
+        "object": "response",
+        "output": [],
+        "parallel_tool_calls": False,
+        "tool_choice": "auto",
+        "tools": [],
+        "status": "completed",
+    }
+    values.update(kwargs)
+    return Response.model_validate(values)
+
+
+def message(*content: dict) -> dict:
+    return {
+        "type": "message",
+        "id": "msg",
+        "role": "assistant",
+        "status": "completed",
+        "content": list(content),
+    }
+
+
+def test_describe_response_empty():
+    response = create_response()
+
+    assert describe_response(response) == "status='completed', output_text='' (0 chars)"
+
+
+def test_describe_response_incomplete():
+    response = create_response(
+        status="incomplete",
+        incomplete_details={"reason": "max_output_tokens"},
+    )
+
+    assert "incomplete_reason='max_output_tokens'" in describe_response(response)
+
+
+def test_describe_response_error():
+    response = create_response(error={"code": "server_error", "message": "Boom"})
+
+    assert "error='server_error': 'Boom'" in describe_response(response)
+
+
+def test_describe_response_refusal():
+    response = create_response(
+        output=[message({"type": "refusal", "refusal": "No."})],
+    )
+
+    assert "refusal='No.'" in describe_response(response)
+
+
+@pytest.mark.parametrize(
+    "text, expected",
+    [
+        ("", "output_text='' (0 chars)"),
+        ('{"topics": []}', "output_text='{\"topics\": []}' (14 chars)"),
+    ],
+)
+def test_describe_response_output_text(text, expected):
+    response = create_response(
+        output=[message({"type": "output_text", "text": text, "annotations": []})],
+    )
+
+    assert expected in describe_response(response)


### PR DESCRIPTION
## Why

The last few CI runs on `main` failed in the `sync-2` job → newsletter club-summary step with an opaque error:

```
jg.coop.sync.newsletter.summary  Summarizing the feed, 347928 characters… (takes a while)
jg.coop.lib.llm  Schema validation failed, attempt #1: Invalid JSON: EOF ... input_value=''
jg.coop.lib.llm  Schema validation failed, attempt #2: ... input_value=''
pydantic_core.ValidationError: 1 validation error for LLMSummary
  Invalid JSON: EOF while parsing a value at line 1 column 0 [input_value='']
```

The OpenAI Responses API returns an **empty message** for the club-summary call, so `LLMSummary` can't be parsed. Retries can't help — the input is fixed, so every attempt gets the same empty output. It repeats deterministically (nightly 15581 Sep 1, push 15586 Sep 2), so it's a real regression, not a flake.

The old code used `client.responses.parse()`, which parses the structured output **inside the SDK** and raises `ValidationError` before we can see *why* the response was empty (incomplete / max output tokens / refusal / content filter).

## What

- Fetch the raw response via `with_raw_response.parse()`, base-parse it into a `Response` object (which never throws on empty output), and validate the schema ourselves.
- On validation failure, log `status`, `incomplete_details.reason`, any `refusal`, and an `output_text` snippet — so the next CI run shows the actual cause. Logged as a `warning` on non-final attempts and as an `error` right before the final `raise`.
- Non-2xx responses (rate limit, 5xx) still raise before the raw wrapper returns, so the existing `tenacity` retry decorators keep working unchanged.
- Add unit tests for the new `describe_response` helper.

This is a **diagnostics** change — it does not fix the empty-response cause (couldn't reproduce locally: no API key / DB), but surfaces the reason so we can pin it from the next run's logs.

## Notes

- `uv run jg tidy --code` couldn't run its SCSS step in this environment (`stylelint-config-twbs-bootstrap` missing) — unrelated to this diff (no SCSS touched). `ruff check`, `ruff format --check`, and the new tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DCPaCseYDp3nErytjsgRWJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01DCPaCseYDp3nErytjsgRWJ)_