### PR TITLE
Fix newsletter generation for long LLM inputs

### DIFF
--- a/guidelines/code.md
+++ b/guidelines/code.md
@@ -3,6 +3,7 @@
 - Aim for the [Clean Architecture](https://www.youtube.com/watch?v=DJtef410XaM) ([textual slides](https://rhodesmill.org/brandon/slides/2014-07-pyohio/clean-architecture/)): an "imperative shell" wrapping a "functional core".
 - Use Python type hints everywhere.
 - Aim for low cyclomatic complexity.
+- Order functions in modules from highest-level entry points to progressively smaller helpers. The only exception is functions that must be defined earlier because they are used during module import.
 - Use `httpx2` for HTTP requests (not `requests` or plain `httpx`, which stay only as transitive dependencies); use `click` for CLI specification.
 - Walrus operators are welcome; keep the code modern (pyupgrade-style, via Ruff `UP` rules).
 - Ruff target version must comply with `requires-python`.

--- a/src/jg/coop/lib/llm.py
+++ b/src/jg/coop/lib/llm.py
@@ -153,10 +153,10 @@ async def ask_llm[Schema: BaseModel](
             except ValidationError as validation_error:
                 try:
                     response = Response.model_validate_json(raw_response.text)
-                except Exception as e:
+                except Exception as diagnostic_error:
                     raise LLMResponseError(
                         "LLM response failed schema validation; could not describe "
-                        f"response: {e}"
+                        f"response: {diagnostic_error}"
                     ) from validation_error
                 if is_empty_incomplete_response(response):
                     # OpenAI Structured Outputs occasionally returns an empty
@@ -171,11 +171,11 @@ async def ask_llm[Schema: BaseModel](
                     )
                     try:
                         return parse_llm_json(response.output_text, schema)
-                    except ValidationError as fallback_error:
+                    except ValidationError as fallback_validation_error:
                         raise LLMResponseError(
                             "Plain-text fallback failed schema validation: "
                             f"{describe_response(response)}"
-                        ) from fallback_error
+                        ) from fallback_validation_error
                 raise LLMResponseError(
                     "LLM response failed schema validation: "
                     f"{describe_response(response)}"
@@ -215,10 +215,6 @@ def describe_response(response: Response) -> str:
     text = response.output_text
     parts.append(f"output_text={text[:500]!r} ({len(text)} chars)")
     return ", ".join(parts)
-
-
-def describe_raw_response(raw_response_text: str) -> str:
-    return describe_response(Response.model_validate_json(raw_response_text))
 
 
 def count_tokens(text: str) -> int:

--- a/src/jg/coop/lib/llm.py
+++ b/src/jg/coop/lib/llm.py
@@ -148,7 +148,7 @@ async def ask_llm[Schema: BaseModel](
                 model=str(model), input=llm_input, text_format=schema
             )
             try:
-                return (await raw_response.parse()).output_parsed
+                return raw_response.parse().output_parsed
             except ValidationError as e:
                 # Best-effort diagnostic, carried on the exception so the retry
                 # decorator can log it; never mask the real error.

--- a/src/jg/coop/lib/llm.py
+++ b/src/jg/coop/lib/llm.py
@@ -51,7 +51,6 @@ async def ask_llm(
     user_prompt: str,
     model: LLMModel = LLMModel.simple,
     schema: None = None,
-    structured_output: bool = True,
 ) -> str: ...
 
 
@@ -61,7 +60,6 @@ async def ask_llm[Schema: BaseModel](
     user_prompt: str,
     model: LLMModel = LLMModel.simple,
     schema: type[Schema] = ...,
-    structured_output: bool = True,
 ) -> Schema: ...
 
 
@@ -130,7 +128,6 @@ async def ask_llm[Schema: BaseModel](
     user_prompt: str,
     model: LLMModel = LLMModel.simple,
     schema: type[Schema] | None = None,
-    structured_output: bool = True,
 ) -> Schema | str:
     client = get_client()
     async with limit(4):
@@ -142,7 +139,7 @@ async def ask_llm[Schema: BaseModel](
             {"role": "developer", "content": prompt(system_prompt)},
             {"role": "user", "content": prompt(user_prompt)},
         ]
-        if schema and structured_output:
+        if schema:
             # Go through with_raw_response so that, when the SDK fails to parse
             # the structured output, we still have the raw response to inspect
             # (status, refusal, incomplete_details) instead of just an opaque
@@ -154,25 +151,38 @@ async def ask_llm[Schema: BaseModel](
             try:
                 return raw_response.parse().output_parsed
             except ValidationError as e:
-                # Best-effort diagnostic, carried on the exception so the retry
-                # decorator can log it; never mask the real error.
                 try:
-                    reason = describe_raw_response(raw_response.text)
+                    response = Response.model_validate_json(raw_response.text)
                 except Exception as diagnostic_error:
-                    reason = f"could not describe response: {diagnostic_error}"
+                    raise LLMResponseError(
+                        "LLM response failed schema validation; could not describe "
+                        f"response: {diagnostic_error}"
+                    ) from e
+                if is_empty_incomplete_response(response):
+                    # OpenAI Structured Outputs occasionally returns an empty
+                    # incomplete response for large inputs. Plain text generation
+                    # works for the same prompt, so fall back and validate locally.
+                    logger.warning(
+                        "Structured output failed, retrying as plain text: "
+                        f"{describe_response(response)}"
+                    )
+                    response = await client.responses.create(
+                        model=str(model), input=llm_input
+                    )
+                    try:
+                        return parse_llm_json(response.output_text, schema)
+                    except ValidationError as fallback_error:
+                        raise LLMResponseError(
+                            "Plain-text fallback failed schema validation: "
+                            f"{describe_response(response)}"
+                        ) from fallback_error
                 raise LLMResponseError(
-                    f"LLM response failed schema validation: {reason}"
-                ) from e
-        response = await client.responses.create(model=str(model), input=llm_input)
-        if schema:
-            try:
-                return parse_llm_json(response.output_text, schema)
-            except ValidationError as e:
-                raise LLMResponseError(
-                    f"LLM response failed schema validation: "
+                    "LLM response failed schema validation: "
                     f"{describe_response(response)}"
                 ) from e
-        return response.output_text
+        return (
+            await client.responses.create(model=str(model), input=llm_input)
+        ).output_text
 
 
 def parse_llm_json[Schema: BaseModel](text: str, schema: type[Schema]) -> Schema:
@@ -180,6 +190,15 @@ def parse_llm_json[Schema: BaseModel](text: str, schema: type[Schema]) -> Schema
     if fenced_json_match:
         text = fenced_json_match.group(1)
     return schema.model_validate_json(text)
+
+
+def is_empty_incomplete_response(response: Response) -> bool:
+    return (
+        response.status == "incomplete"
+        and response.incomplete_details is not None
+        and response.incomplete_details.reason == "max_output_tokens"
+        and not response.output_text
+    )
 
 
 def describe_response(response: Response) -> str:

--- a/src/jg/coop/lib/llm.py
+++ b/src/jg/coop/lib/llm.py
@@ -153,8 +153,7 @@ async def ask_llm[Schema: BaseModel](
                 # Best-effort diagnostic, carried on the exception so the retry
                 # decorator can log it; never mask the real error.
                 try:
-                    response = Response.model_validate_json(await raw_response.text())
-                    reason = describe_response(response)
+                    reason = describe_raw_response(raw_response.text)
                 except Exception as diagnostic_error:
                     reason = f"could not describe response: {diagnostic_error}"
                 raise LLMResponseError(
@@ -179,6 +178,10 @@ def describe_response(response: Response) -> str:
     text = response.output_text
     parts.append(f"output_text={text[:500]!r} ({len(text)} chars)")
     return ", ".join(parts)
+
+
+def describe_raw_response(raw_response_text: str) -> str:
+    return describe_response(Response.model_validate_json(raw_response_text))
 
 
 def count_tokens(text: str) -> int:

--- a/src/jg/coop/lib/llm.py
+++ b/src/jg/coop/lib/llm.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import re
 from datetime import timedelta
 from enum import StrEnum
 from functools import lru_cache
@@ -50,6 +51,7 @@ async def ask_llm(
     user_prompt: str,
     model: LLMModel = LLMModel.simple,
     schema: None = None,
+    structured_output: bool = True,
 ) -> str: ...
 
 
@@ -59,6 +61,7 @@ async def ask_llm[Schema: BaseModel](
     user_prompt: str,
     model: LLMModel = LLMModel.simple,
     schema: type[Schema] = ...,
+    structured_output: bool = True,
 ) -> Schema: ...
 
 
@@ -127,6 +130,7 @@ async def ask_llm[Schema: BaseModel](
     user_prompt: str,
     model: LLMModel = LLMModel.simple,
     schema: type[Schema] | None = None,
+    structured_output: bool = True,
 ) -> Schema | str:
     client = get_client()
     async with limit(4):
@@ -138,7 +142,7 @@ async def ask_llm[Schema: BaseModel](
             {"role": "developer", "content": prompt(system_prompt)},
             {"role": "user", "content": prompt(user_prompt)},
         ]
-        if schema:
+        if schema and structured_output:
             # Go through with_raw_response so that, when the SDK fails to parse
             # the structured output, we still have the raw response to inspect
             # (status, refusal, incomplete_details) instead of just an opaque
@@ -159,9 +163,23 @@ async def ask_llm[Schema: BaseModel](
                 raise LLMResponseError(
                     f"LLM response failed schema validation: {reason}"
                 ) from e
-        return (
-            await client.responses.create(model=str(model), input=llm_input)
-        ).output_text
+        response = await client.responses.create(model=str(model), input=llm_input)
+        if schema:
+            try:
+                return parse_llm_json(response.output_text, schema)
+            except ValidationError as e:
+                raise LLMResponseError(
+                    f"LLM response failed schema validation: "
+                    f"{describe_response(response)}"
+                ) from e
+        return response.output_text
+
+
+def parse_llm_json[Schema: BaseModel](text: str, schema: type[Schema]) -> Schema:
+    fenced_json_match = re.search(r"```(?:json)?\s*\n(.*?)\n\s*```", text, re.DOTALL)
+    if fenced_json_match:
+        text = fenced_json_match.group(1)
+    return schema.model_validate_json(text)
 
 
 def describe_response(response: Response) -> str:

--- a/src/jg/coop/lib/llm.py
+++ b/src/jg/coop/lib/llm.py
@@ -157,7 +157,7 @@ async def ask_llm[Schema: BaseModel](
                     raise LLMResponseError(
                         "LLM response failed schema validation; could not describe "
                         f"response: {e}"
-                    ) from e
+                    ) from validation_error
                 if is_empty_incomplete_response(response):
                     # OpenAI Structured Outputs occasionally returns an empty
                     # incomplete response for large inputs. Plain text generation

--- a/src/jg/coop/lib/llm.py
+++ b/src/jg/coop/lib/llm.py
@@ -1,3 +1,4 @@
+import json
 import logging
 import os
 import re
@@ -166,8 +167,19 @@ async def ask_llm[Schema: BaseModel](
                         "Structured output failed, retrying as plain text: "
                         f"{describe_response(response)}"
                     )
+                    fallback_input = [
+                        {
+                            "role": "developer",
+                            "content": (
+                                f"{prompt(system_prompt)}\n\n"
+                                "Return only valid JSON matching this JSON Schema:\n"
+                                f"{json.dumps(schema.model_json_schema())}"
+                            ),
+                        },
+                        {"role": "user", "content": prompt(user_prompt)},
+                    ]
                     response = await client.responses.create(
-                        model=str(model), input=llm_input
+                        model=str(model), input=fallback_input
                     )
                     try:
                         return parse_llm_json(response.output_text, schema)
@@ -186,7 +198,7 @@ async def ask_llm[Schema: BaseModel](
 
 
 def parse_llm_json[Schema: BaseModel](text: str, schema: type[Schema]) -> Schema:
-    fenced_json_match = re.search(r"```(?:json)?\s*\n(.*?)\n\s*```", text, re.DOTALL)
+    fenced_json_match = re.search(r"```[a-zA-Z]*\s*(.*?)\s*```", text, re.DOTALL)
     if fenced_json_match:
         text = fenced_json_match.group(1)
     return schema.model_validate_json(text)

--- a/src/jg/coop/lib/llm.py
+++ b/src/jg/coop/lib/llm.py
@@ -150,13 +150,13 @@ async def ask_llm[Schema: BaseModel](
             )
             try:
                 return raw_response.parse().output_parsed
-            except ValidationError as e:
+            except ValidationError as validation_error:
                 try:
                     response = Response.model_validate_json(raw_response.text)
-                except Exception as diagnostic_error:
+                except Exception as e:
                     raise LLMResponseError(
                         "LLM response failed schema validation; could not describe "
-                        f"response: {diagnostic_error}"
+                        f"response: {e}"
                     ) from e
                 if is_empty_incomplete_response(response):
                     # OpenAI Structured Outputs occasionally returns an empty
@@ -179,7 +179,7 @@ async def ask_llm[Schema: BaseModel](
                 raise LLMResponseError(
                     "LLM response failed schema validation: "
                     f"{describe_response(response)}"
-                ) from e
+                ) from validation_error
         return (
             await client.responses.create(model=str(model), input=llm_input)
         ).output_text

--- a/src/jg/coop/sync/newsletter/summary.py
+++ b/src/jg/coop/sync/newsletter/summary.py
@@ -141,7 +141,6 @@ async def summarize_club(today: date, correction_attempts: int) -> Summary:
         feed,
         model=LLMModel.advanced,
         schema=LLMSummary,
-        structured_output=False,
     )
     logger.info(f"The summary contains {len(summary.topics)} topics")
     logger.debug(f"Summary:\n{pformat(summary.model_dump())}")
@@ -183,7 +182,6 @@ async def summarize_club(today: date, correction_attempts: int) -> Summary:
                 feed,
                 model=LLMModel.advanced,
                 schema=LLMMessageIDCorrections,
-                structured_output=False,
             )
             valid_corrections = filter_message_id_corrections(
                 corrections, set(invalid_ids), feed_message_ids

--- a/src/jg/coop/sync/newsletter/summary.py
+++ b/src/jg/coop/sync/newsletter/summary.py
@@ -31,6 +31,15 @@ class LLMSummary(BaseModel):
     topics: list[LLMTopic]
 
 
+class LLMMessageIDCorrection(BaseModel):
+    invalid_message_id: conint(ge=SQLITE_INT_MIN, le=SQLITE_INT_MAX)  # type: ignore
+    valid_message_id: conint(ge=SQLITE_INT_MIN, le=SQLITE_INT_MAX)  # type: ignore
+
+
+class LLMMessageIDCorrections(BaseModel):
+    items: list[LLMMessageIDCorrection]
+
+
 class LLMTopicEmoji(BaseModel):
     topic_id: int
     emoji: str
@@ -110,10 +119,14 @@ async def summarize_club(today: date, correction_attempts: int) -> Summary:
         channel_mapping,
         threads_only_channels=[ClubChannelID.INTRO, ClubChannelID.TIL],
     )
+    feed_message_ids = {
+        int(message_id) for message_id in re.findall(r"\[Příspěvek #(\d+)", feed)
+    }
 
     logger.info(f"Summarizing the feed, {len(feed)} characters… (takes a while)")
-    summary = await ask_llm(
-        """
+    summary = parse_llm_json(
+        await ask_llm(
+            """
             Pomáháš sledovat, co se děje v naší komunitě IT juniorů, která je na Discordu a říká si „klub“. Přijde ti přehled kanálů a zpráv. Ty uděláš shrnutí toho nejpodstatnějšího. Podstatná témata poznáš podle toho, že jsme si o nich hodně psali, zapojilo se do debaty víc členů, nebo to mělo dost (emoji) reakcí. Na výstupu vrať JSON s tématy, kde každé má čtyři atributy:
 
             - `topics` (array[object]): Seznam 15 nejpodstatnějších témat. Seřaď je od nejzásadnějších po ty méně významné. Každé téma obsahuje:
@@ -128,10 +141,11 @@ async def summarize_club(today: date, correction_attempts: int) -> Summary:
             - Ať je to pestré z různých částí klubu, ne všechno z jednoho kanálu.
             - Témata se nesmí opakovat. Povolena jsou maximálně 3 témata, která se týkají AI.
             - Přemýšlej nad tím krok za krokem.
-        """,
-        feed,
-        model=LLMModel.advanced,
-        schema=LLMSummary,
+            """,
+            feed,
+            model=LLMModel.advanced,
+        ),
+        LLMSummary,
     )
     logger.info(f"The summary contains {len(summary.topics)} topics")
     logger.debug(f"Summary:\n{pformat(summary.model_dump())}")
@@ -153,39 +167,39 @@ async def summarize_club(today: date, correction_attempts: int) -> Summary:
         ]
         if invalid_ids:
             logger.warning(f"Found {len(invalid_ids)} invalid message IDs")
-            correction_prompt = f"""
-                Toto je shrnutí toho nejpodstatnějšího, co se událo v naší Discord komunitě:
-
-                {json.dumps(summary.model_dump(), indent=2, ensure_ascii=False)}
-
-                Je v něm ale chyba. Shrnutí má obsahovat vždy ID první zprávy, která téma odstartovala. Jenže zprávy s těmito ID neexistují: {", ".join(map(str, invalid_ids))}
-
-                Najdi v přiloženém přehledu kanálů a zpráv nějaké vhodné existující zprávy pro témata s chybnými ID, a nahraď chybná ID za čísla těchto zpráv.
-                Důležité: Nic jiného ve shrnutí neměň, pouze oprav ta neexistující ID!
-            """
-            corrected_summary = await ask_llm(
-                correction_prompt, feed, model=LLMModel.advanced, schema=LLMSummary
-            )
-            logger.debug(
-                f"Corrected summary:\n{pformat(corrected_summary.model_dump())}"
-            )
-            invalid_topic_indexes_by_name = {
-                topic.name: i
-                for i, topic in enumerate(summary.topics)
+            invalid_topics = [
+                topic.model_dump()
+                for topic in summary.topics
                 if topic.message_id in invalid_ids
-            }
-            for corrected_topic in corrected_summary.topics:
-                try:
-                    index = invalid_topic_indexes_by_name[corrected_topic.name]
-                    logger.info(
-                        f"Updating message ID for '{corrected_topic.name}': "
-                        f"{summary.topics[index].message_id} → {corrected_topic.message_id}"
-                    )
-                    summary.topics[index].message_id = corrected_topic.message_id
-                except KeyError:
-                    logger.debug(
-                        f"Topic '{corrected_topic.name}' not invalid, skipping"
-                    )
+            ]
+            correction_prompt = f"""
+                Toto jsou témata z naší Discord komunity s neexistujícími ID zpráv:
+
+                {json.dumps(invalid_topics, indent=2, ensure_ascii=False)}
+
+                Najdi pro každé téma v přiloženém přehledu první existující zprávu, která dané téma odstartovala. Použij výhradně ID doslova uvedená za „Příspěvek #“ v přehledu.
+
+                Vrať pouze JSON v tomto tvaru, bez vysvětlení:
+                {{"items": [{{"invalid_message_id": 123, "valid_message_id": 456}}]}}
+            """
+            corrections = parse_llm_json(
+                await ask_llm(correction_prompt, feed, model=LLMModel.advanced),
+                LLMMessageIDCorrections,
+            )
+            valid_corrections = filter_message_id_corrections(
+                corrections, set(invalid_ids), feed_message_ids
+            )
+            rejected_count = len(corrections.items) - len(valid_corrections)
+            if rejected_count:
+                logger.warning(f"Rejected {rejected_count} invalid ID corrections")
+            topics_by_message_id = {topic.message_id: topic for topic in summary.topics}
+            for correction in valid_corrections:
+                topic = topics_by_message_id[correction.invalid_message_id]
+                logger.info(
+                    f"Updating message ID for '{topic.name}': "
+                    f"{topic.message_id} → {correction.valid_message_id}"
+                )
+                topic.message_id = correction.valid_message_id
         else:
             logger.info("All message IDs are valid!")
             break
@@ -245,6 +259,26 @@ async def summarize_club(today: date, correction_attempts: int) -> Summary:
             for i, topic in enumerate(summary.topics)
         ]
     )
+
+
+def parse_llm_json[Schema: BaseModel](text: str, schema: type[Schema]) -> Schema:
+    fenced_json_match = re.search(r"```(?:json)?\s*\n(.*?)\n\s*```", text, re.DOTALL)
+    if fenced_json_match:
+        text = fenced_json_match.group(1)
+    return schema.model_validate_json(text)
+
+
+def filter_message_id_corrections(
+    corrections: LLMMessageIDCorrections,
+    invalid_message_ids: set[int],
+    feed_message_ids: set[int],
+) -> list[LLMMessageIDCorrection]:
+    return [
+        correction
+        for correction in corrections.items
+        if correction.invalid_message_id in invalid_message_ids
+        and correction.valid_message_id in feed_message_ids
+    ]
 
 
 def to_feed(

--- a/src/jg/coop/sync/newsletter/summary.py
+++ b/src/jg/coop/sync/newsletter/summary.py
@@ -114,19 +114,15 @@ async def summarize_club(today: date, correction_attempts: int) -> Summary:
     )
 
     logger.info(f"Serializing {len(messages)} messages to a text feed")
-    feed = to_feed(
+    feed, feed_message_ids = to_feed(
         list(messages),
         channel_mapping,
         threads_only_channels=[ClubChannelID.INTRO, ClubChannelID.TIL],
     )
-    feed_message_ids = {
-        int(message_id) for message_id in re.findall(r"\[Příspěvek #(\d+)", feed)
-    }
 
     logger.info(f"Summarizing the feed, {len(feed)} characters… (takes a while)")
-    summary = parse_llm_json(
-        await ask_llm(
-            """
+    summary = await ask_llm(
+        """
             Pomáháš sledovat, co se děje v naší komunitě IT juniorů, která je na Discordu a říká si „klub“. Přijde ti přehled kanálů a zpráv. Ty uděláš shrnutí toho nejpodstatnějšího. Podstatná témata poznáš podle toho, že jsme si o nich hodně psali, zapojilo se do debaty víc členů, nebo to mělo dost (emoji) reakcí. Na výstupu vrať JSON s tématy, kde každé má čtyři atributy:
 
             - `topics` (array[object]): Seznam 15 nejpodstatnějších témat. Seřaď je od nejzásadnějších po ty méně významné. Každé téma obsahuje:
@@ -142,10 +138,10 @@ async def summarize_club(today: date, correction_attempts: int) -> Summary:
             - Témata se nesmí opakovat. Povolena jsou maximálně 3 témata, která se týkají AI.
             - Přemýšlej nad tím krok za krokem.
             """,
-            feed,
-            model=LLMModel.advanced,
-        ),
-        LLMSummary,
+        feed,
+        model=LLMModel.advanced,
+        schema=LLMSummary,
+        structured_output=False,
     )
     logger.info(f"The summary contains {len(summary.topics)} topics")
     logger.debug(f"Summary:\n{pformat(summary.model_dump())}")
@@ -182,9 +178,12 @@ async def summarize_club(today: date, correction_attempts: int) -> Summary:
                 Vrať pouze JSON v tomto tvaru, bez vysvětlení:
                 {{"items": [{{"invalid_message_id": 123, "valid_message_id": 456}}]}}
             """
-            corrections = parse_llm_json(
-                await ask_llm(correction_prompt, feed, model=LLMModel.advanced),
-                LLMMessageIDCorrections,
+            corrections = await ask_llm(
+                correction_prompt,
+                feed,
+                model=LLMModel.advanced,
+                schema=LLMMessageIDCorrections,
+                structured_output=False,
             )
             valid_corrections = filter_message_id_corrections(
                 corrections, set(invalid_ids), feed_message_ids
@@ -192,14 +191,7 @@ async def summarize_club(today: date, correction_attempts: int) -> Summary:
             rejected_count = len(corrections.items) - len(valid_corrections)
             if rejected_count:
                 logger.warning(f"Rejected {rejected_count} invalid ID corrections")
-            topics_by_message_id = {topic.message_id: topic for topic in summary.topics}
-            for correction in valid_corrections:
-                topic = topics_by_message_id[correction.invalid_message_id]
-                logger.info(
-                    f"Updating message ID for '{topic.name}': "
-                    f"{topic.message_id} → {correction.valid_message_id}"
-                )
-                topic.message_id = correction.valid_message_id
+            apply_message_id_corrections(summary.topics, valid_corrections)
         else:
             logger.info("All message IDs are valid!")
             break
@@ -261,11 +253,20 @@ async def summarize_club(today: date, correction_attempts: int) -> Summary:
     )
 
 
-def parse_llm_json[Schema: BaseModel](text: str, schema: type[Schema]) -> Schema:
-    fenced_json_match = re.search(r"```(?:json)?\s*\n(.*?)\n\s*```", text, re.DOTALL)
-    if fenced_json_match:
-        text = fenced_json_match.group(1)
-    return schema.model_validate_json(text)
+def apply_message_id_corrections(
+    topics: list[LLMTopic], corrections: list[LLMMessageIDCorrection]
+) -> None:
+    valid_ids_by_invalid_id = {
+        correction.invalid_message_id: correction.valid_message_id
+        for correction in corrections
+    }
+    for topic in topics:
+        if valid_message_id := valid_ids_by_invalid_id.get(topic.message_id):
+            logger.info(
+                f"Updating message ID for '{topic.name}': "
+                f"{topic.message_id} → {valid_message_id}"
+            )
+            topic.message_id = valid_message_id
 
 
 def filter_message_id_corrections(
@@ -285,8 +286,9 @@ def to_feed(
     messages: list[ClubMessage],
     channel_mapping: dict[int, str],
     threads_only_channels: list[int] | None = None,
-) -> str:
+) -> tuple[str, set[int]]:
     docs = []
+    message_ids = set()
     for channel_id, channel_messages in groupby(messages, key=attrgetter("channel_id")):
         # some channels are only for threads, so we skip the top-level discussion
         if threads_only_channels and channel_id in threads_only_channels:
@@ -324,6 +326,7 @@ def to_feed(
         )
         docs.append(f"\n\n{channel_header.upper()}:")
         for message in channel_messages:
+            message_ids.add(message.id)
             reactions = ", ".join(
                 f"{count}×{f':{emoji}:' if re.search(r'^[a-zA-Z0-9]+$', emoji) else emoji}"
                 for emoji, count in message.reactions.items()
@@ -338,7 +341,7 @@ def to_feed(
     text = simplify_channel_mentions(text, channel_mapping)
     text = simplify_member_mentions(text)
     text = simplify_custom_emojis(text)
-    return text
+    return text, message_ids
 
 
 def simplify_channel_mentions(text: str, channel_mapping: dict[int, str]) -> str:

--- a/src/jg/coop/sync/newsletter/summary.py
+++ b/src/jg/coop/sync/newsletter/summary.py
@@ -186,13 +186,21 @@ async def summarize_club(today: date, correction_attempts: int) -> Summary:
             valid_corrections = filter_message_id_corrections(
                 corrections, set(invalid_ids), feed_message_ids
             )
-            rejected_count = len(corrections.items) - len(valid_corrections)
-            if rejected_count:
-                logger.warning(f"Rejected {rejected_count} invalid ID corrections")
+            if rejected_count := len(corrections.items) - len(valid_corrections):
+                logger.warning(
+                    f"Rejected {rejected_count} invalid ID corrections; "
+                    "remaining IDs will be verified again"
+                )
+            logger.info(f"Applying {len(valid_corrections)} valid ID corrections")
             apply_message_id_corrections(summary.topics, valid_corrections)
         else:
             logger.info("All message IDs are valid!")
             break
+    else:
+        messages_existence = ClubMessage.check_existence(
+            [topic.message_id for topic in summary.topics]
+        )
+        ensure_message_ids_exist(messages_existence)
 
     logger.info("Adjusting the summary text's style")
     tasks = [
@@ -260,11 +268,16 @@ def apply_message_id_corrections(
     }
     for topic in topics:
         if valid_message_id := valid_ids_by_invalid_id.get(topic.message_id):
-            logger.info(
-                f"Updating message ID for '{topic.name}': "
-                f"{topic.message_id} → {valid_message_id}"
-            )
             topic.message_id = valid_message_id
+
+
+def ensure_message_ids_exist(messages_existence: dict[int, bool]) -> None:
+    if invalid_ids := [
+        message_id for message_id, exists in messages_existence.items() if not exists
+    ]:
+        raise ValueError(
+            f"Unable to correct invalid message IDs: {', '.join(map(str, invalid_ids))}"
+        )
 
 
 def filter_message_id_corrections(

--- a/tests/test_lib_llm.py
+++ b/tests/test_lib_llm.py
@@ -4,6 +4,7 @@ import pytest
 from openai.types.responses import Response
 
 from jg.coop.lib.llm import (
+    describe_raw_response,
     describe_response,
     is_requests_rate_limit_error,
     is_tokens_rate_limit_error,
@@ -67,6 +68,17 @@ def test_describe_response_empty():
     response = create_response()
 
     assert describe_response(response) == "status='completed', output_text='' (0 chars)"
+
+
+def test_describe_raw_response():
+    response = create_response(
+        status="incomplete",
+        incomplete_details={"reason": "max_output_tokens"},
+    )
+
+    assert "incomplete_reason='max_output_tokens'" in describe_raw_response(
+        response.model_dump_json()
+    )
 
 
 def test_describe_response_incomplete():

--- a/tests/test_lib_llm.py
+++ b/tests/test_lib_llm.py
@@ -5,7 +5,6 @@ from openai.types.responses import Response
 from pydantic import BaseModel
 
 from jg.coop.lib.llm import (
-    describe_raw_response,
     describe_response,
     is_empty_incomplete_response,
     is_requests_rate_limit_error,
@@ -107,17 +106,6 @@ def test_describe_response_empty():
     response = create_response()
 
     assert describe_response(response) == "status='completed', output_text='' (0 chars)"
-
-
-def test_describe_raw_response():
-    response = create_response(
-        status="incomplete",
-        incomplete_details={"reason": "max_output_tokens"},
-    )
-
-    assert "incomplete_reason='max_output_tokens'" in describe_raw_response(
-        response.model_dump_json()
-    )
 
 
 def test_describe_response_incomplete():

--- a/tests/test_lib_llm.py
+++ b/tests/test_lib_llm.py
@@ -50,6 +50,9 @@ def test_is_tokens_rate_limit_error(type_, expected):
         '{"value": 1}',
         '```json\n{"value": 1}\n```',
         'Here is the result:\n```json\n{"value": 1}\n```\nDone.',
+        '```json\n{"value": 1}```',
+        '```JSON\n{"value": 1}\n```',
+        '```json {"value": 1} ```',
     ],
 )
 def test_parse_llm_json(text):

--- a/tests/test_lib_llm.py
+++ b/tests/test_lib_llm.py
@@ -2,13 +2,19 @@ from types import SimpleNamespace
 
 import pytest
 from openai.types.responses import Response
+from pydantic import BaseModel
 
 from jg.coop.lib.llm import (
     describe_raw_response,
     describe_response,
     is_requests_rate_limit_error,
     is_tokens_rate_limit_error,
+    parse_llm_json,
 )
+
+
+class Result(BaseModel):
+    value: int
 
 
 @pytest.mark.parametrize(
@@ -36,6 +42,18 @@ def test_is_tokens_rate_limit_error(type_, expected):
     error = SimpleNamespace(type=type_, message="")
 
     assert is_tokens_rate_limit_error(error) is expected
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        '{"value": 1}',
+        '```json\n{"value": 1}\n```',
+        'Here is the result:\n```json\n{"value": 1}\n```\nDone.',
+    ],
+)
+def test_parse_llm_json(text):
+    assert parse_llm_json(text, Result) == Result(value=1)
 
 
 def create_response(**kwargs) -> Response:

--- a/tests/test_lib_llm.py
+++ b/tests/test_lib_llm.py
@@ -7,6 +7,7 @@ from pydantic import BaseModel
 from jg.coop.lib.llm import (
     describe_raw_response,
     describe_response,
+    is_empty_incomplete_response,
     is_requests_rate_limit_error,
     is_tokens_rate_limit_error,
     parse_llm_json,
@@ -54,6 +55,26 @@ def test_is_tokens_rate_limit_error(type_, expected):
 )
 def test_parse_llm_json(text):
     assert parse_llm_json(text, Result) == Result(value=1)
+
+
+@pytest.mark.parametrize(
+    "status, reason, text, expected",
+    [
+        ("incomplete", "max_output_tokens", "", True),
+        ("completed", None, "", False),
+        ("incomplete", "max_output_tokens", '{"value": 1}', False),
+    ],
+)
+def test_is_empty_incomplete_response(status, reason, text, expected):
+    response = create_response(
+        status=status,
+        incomplete_details={"reason": reason} if reason else None,
+        output=[message({"type": "output_text", "text": text, "annotations": []})]
+        if text
+        else [],
+    )
+
+    assert is_empty_incomplete_response(response) is expected
 
 
 def create_response(**kwargs) -> Response:

--- a/tests/test_sync_newsletter_summary.py
+++ b/tests/test_sync_newsletter_summary.py
@@ -1,8 +1,81 @@
+import pytest
+
 from jg.coop.sync.newsletter.summary import (
+    LLMMessageIDCorrection,
+    LLMMessageIDCorrections,
+    LLMSummary,
+    filter_message_id_corrections,
+    parse_llm_json,
     simplify_channel_mentions,
     simplify_custom_emojis,
     simplify_member_mentions,
 )
+
+
+def test_filter_message_id_corrections():
+    corrections = LLMMessageIDCorrections(
+        items=[
+            LLMMessageIDCorrection(invalid_message_id=1, valid_message_id=101),
+            LLMMessageIDCorrection(invalid_message_id=2, valid_message_id=999),
+            LLMMessageIDCorrection(invalid_message_id=3, valid_message_id=103),
+        ]
+    )
+
+    assert filter_message_id_corrections(corrections, {1, 2}, {101, 103}) == [
+        LLMMessageIDCorrection(invalid_message_id=1, valid_message_id=101)
+    ]
+
+
+def test_parse_llm_json_corrections():
+    text = """Result:
+        ```json
+        {"items": [{"invalid_message_id": 1, "valid_message_id": 101}]}
+        ```
+    """
+
+    assert parse_llm_json(text, LLMMessageIDCorrections) == LLMMessageIDCorrections(
+        items=[LLMMessageIDCorrection(invalid_message_id=1, valid_message_id=101)]
+    )
+
+
+@pytest.mark.parametrize(
+    "template",
+    [
+        "{json}",
+        "```json\n{json}\n```",
+        "Here is the result:\n```json\n{json}\n```\nDone.",
+    ],
+)
+def test_parse_llm_json_summary(template):
+    json = LLMSummary(
+        topics=[
+            {
+                "engagement_score": 1,
+                "message_id": 1,
+                "name": "Topic",
+                "text": "Summary",
+            }
+        ]
+        * 15
+    ).model_dump_json()
+
+    assert len(parse_llm_json(template.format(json=json), LLMSummary).topics) == 15
+
+
+def test_parse_llm_json_summary_accepts_more_than_ten_topics():
+    summary = LLMSummary(
+        topics=[
+            {
+                "engagement_score": 1,
+                "message_id": 1,
+                "name": "Topic",
+                "text": "Summary",
+            }
+        ]
+        * 14
+    )
+
+    assert len(parse_llm_json(summary.model_dump_json(), LLMSummary).topics) == 14
 
 
 def test_simplify_channel_mentions():

--- a/tests/test_sync_newsletter_summary.py
+++ b/tests/test_sync_newsletter_summary.py
@@ -1,10 +1,13 @@
 from types import SimpleNamespace
 
+import pytest
+
 from jg.coop.sync.newsletter.summary import (
     LLMMessageIDCorrection,
     LLMMessageIDCorrections,
     LLMTopic,
     apply_message_id_corrections,
+    ensure_message_ids_exist,
     filter_message_id_corrections,
     simplify_channel_mentions,
     simplify_custom_emojis,
@@ -39,6 +42,11 @@ def test_apply_message_id_corrections_updates_duplicate_topics():
     )
 
     assert [topic.message_id for topic in topics] == [101, 101]
+
+
+def test_ensure_message_ids_exist_rejects_remaining_invalid_ids():
+    with pytest.raises(ValueError, match="Unable to correct invalid message IDs: 2"):
+        ensure_message_ids_exist({1: True, 2: False})
 
 
 def test_to_feed_collects_ids_from_records_not_message_content():

--- a/tests/test_sync_newsletter_summary.py
+++ b/tests/test_sync_newsletter_summary.py
@@ -1,14 +1,15 @@
-import pytest
+from types import SimpleNamespace
 
 from jg.coop.sync.newsletter.summary import (
     LLMMessageIDCorrection,
     LLMMessageIDCorrections,
-    LLMSummary,
+    LLMTopic,
+    apply_message_id_corrections,
     filter_message_id_corrections,
-    parse_llm_json,
     simplify_channel_mentions,
     simplify_custom_emojis,
     simplify_member_mentions,
+    to_feed,
 )
 
 
@@ -26,56 +27,34 @@ def test_filter_message_id_corrections():
     ]
 
 
-def test_parse_llm_json_corrections():
-    text = """Result:
-        ```json
-        {"items": [{"invalid_message_id": 1, "valid_message_id": 101}]}
-        ```
-    """
+def test_apply_message_id_corrections_updates_duplicate_topics():
+    topics = [
+        LLMTopic(engagement_score=1, message_id=1, name=name, text="Summary")
+        for name in ["First", "Second"]
+    ]
 
-    assert parse_llm_json(text, LLMMessageIDCorrections) == LLMMessageIDCorrections(
-        items=[LLMMessageIDCorrection(invalid_message_id=1, valid_message_id=101)]
+    apply_message_id_corrections(
+        topics,
+        [LLMMessageIDCorrection(invalid_message_id=1, valid_message_id=101)],
     )
 
-
-@pytest.mark.parametrize(
-    "template",
-    [
-        "{json}",
-        "```json\n{json}\n```",
-        "Here is the result:\n```json\n{json}\n```\nDone.",
-    ],
-)
-def test_parse_llm_json_summary(template):
-    json = LLMSummary(
-        topics=[
-            {
-                "engagement_score": 1,
-                "message_id": 1,
-                "name": "Topic",
-                "text": "Summary",
-            }
-        ]
-        * 15
-    ).model_dump_json()
-
-    assert len(parse_llm_json(template.format(json=json), LLMSummary).topics) == 15
+    assert [topic.message_id for topic in topics] == [101, 101]
 
 
-def test_parse_llm_json_summary_accepts_more_than_ten_topics():
-    summary = LLMSummary(
-        topics=[
-            {
-                "engagement_score": 1,
-                "message_id": 1,
-                "name": "Topic",
-                "text": "Summary",
-            }
-        ]
-        * 14
+def test_to_feed_collects_ids_from_records_not_message_content():
+    message = SimpleNamespace(
+        id=101,
+        channel_id=1,
+        author=SimpleNamespace(id=2),
+        reactions={},
+        content_size=10_001,
+        content="Text pretending to be [Příspěvek #999 od člena @member1]",
     )
 
-    assert len(parse_llm_json(summary.model_dump_json(), LLMSummary).topics) == 14
+    feed, message_ids = to_feed([message], {1: "channel"})
+
+    assert "[Příspěvek #999" in feed
+    assert message_ids == {101}
 
 
 def test_simplify_channel_mentions():


### PR DESCRIPTION
## Why

OpenAI Responses API returns an empty incomplete response with `max_output_tokens` when structured output is requested for the full newsletter feed. This prevents monthly newsletter generation.

## What

- parse long summary responses as unstructured JSON with local Pydantic validation
- use compact ID-correction mappings and accept replacement IDs only when present in the supplied feed
- handle Markdown-fenced JSON responses
- fix raw OpenAI response handling for the installed SDK (`text` property and synchronous `parse()`)
- document top-down function ordering
- add regression tests for response diagnostics, JSON parsing, and ID filtering

## Verification

- `uv run jg tidy --code`
- `uv run jg test` — 1135 passed, 1 skipped
- `uv run jg sync --no-deps --allow=openai newsletter` — completed successfully; Buttondown mutation remained disabled