### PR TITLE
Add location rewrite rule for České Budějovice

### DIFF
--- a/src/jg/coop/lib/location.py
+++ b/src/jg/coop/lib/location.py
@@ -52,6 +52,7 @@ REWRITES_RE = {
     re.compile(r"\bBratislava\W+[IV]{1,3}\b", re.IGNORECASE): "Bratislava",
     re.compile(r"\bBrno\W+(Staré Brno|Střed)\b", re.IGNORECASE): "Brno",
     re.compile(r"\bCentral Bohemia\b", re.IGNORECASE): "Středočeský kraj",
+    re.compile(r"^.*\bČeské Budějovice\b.*$", re.IGNORECASE): "České Budějovice",
     re.compile(r"\bMetropolitan Area\b", re.IGNORECASE): "",
     re.compile(r"\bMoravia-Silesia\b", re.IGNORECASE): "Moravskoslezský kraj",
     re.compile(r"\bPraha\W+(východ|západ)\b", re.IGNORECASE): "Středočeský kraj",

--- a/tests/test_lib_location.py
+++ b/tests/test_lib_location.py
@@ -42,6 +42,13 @@ from jg.coop.lib.location import (
                 ResponseRegionType.municipality,
             ),
         ),
+        (
+            "Národní pavilon Z – Výstaviště České Budějovice, České Budějovice & REUSE festival",
+            (
+                "České Budějovice",
+                ResponseRegionType.municipality,
+            ),
+        ),
     ],
 )
 def test_generate_queries_rewrite(location_raw, expected):


### PR DESCRIPTION
Add pattern matching to normalize location strings containing "České Budějovice" to canonical form.

Changes:
- Add regex rule to `LOCATION_REWRITES` dict matching any string containing "České Budějovice" (case-insensitive)
- Add test case validating extraction from complex venue/event string with multiple location references

The pattern uses `^.*\bČeské Budějovice\b.*$` to match the municipality name as a word boundary anywhere in the input, ensuring consistent normalization of location data regardless of surrounding text.

https://claude.ai/code/session_018vbE1rHmKSf8KiQ1oCmTgC