### PR TITLE
Fix dead umimeto.org research link in handbook

### DIFF
--- a/src/jg/coop/web/docs/handbook/english.md
+++ b/src/jg/coop/web/docs/handbook/english.md
@@ -57,7 +57,7 @@ template: main_handbook.html
     badge_icon='list-check',
     badge_text='Cvičení',
   ) -%}
-    Systém učení skrze cvičení a opakování. [Podloženo výzkumem](https://www.umimeto.org/podlozeno-vyzkumem).
+    Systém učení skrze cvičení a opakování. [Podloženo výzkumem](https://www.umimeto.org/shrnuti-vyzkum-umime).
   {%- endcall %}
 
   {{ link_card(

--- a/src/jg/coop/web/docs/handbook/learn.md
+++ b/src/jg/coop/web/docs/handbook/learn.md
@@ -150,7 +150,7 @@ Nemusíš se přebírat hromadami možností a přemýšlet, do které se vyplat
     badge_icon='list-check',
     badge_text='Cvičení',
   ) -%}
-    Uč se skrze cvičení a opakování. [Podloženo výzkumem](https://www.umimeto.org/podlozeno-vyzkumem).
+    Uč se skrze cvičení a opakování. [Podloženo výzkumem](https://www.umimeto.org/shrnuti-vyzkum-umime).
   {%- endcall %}
 
   {{ link_card(

--- a/src/jg/coop/web/docs/handbook/practice.md
+++ b/src/jg/coop/web/docs/handbook/practice.md
@@ -46,7 +46,7 @@ template: main_handbook.html
     'Umíme informatiku',
     'https://www.umimeinformatiku.cz',
   ) -%}
-    Uč se skrze cvičení a opakování. [Podloženo výzkumem](https://www.umimeto.org/podlozeno-vyzkumem).
+    Uč se skrze cvičení a opakování. [Podloženo výzkumem](https://www.umimeto.org/shrnuti-vyzkum-umime).
   {%- endcall %}
 
   {{ link_card(


### PR DESCRIPTION
## What

The "Podloženo výzkumem" link in the handbook pointed to `https://www.umimeto.org/podlozeno-vyzkumem`, which now returns **404**. The page moved to `https://www.umimeto.org/shrnuti-vyzkum-umime` (verified 200, its `<h1>` is literally "Podloženo výzkumem" — same content).

## Why

This dead link was failing the nightly `check-links` job (CircleCI pipeline 15618 and again the following night). This was the only real error in the run.

## Changes

Replaced the URL in the 3 files that referenced it:

- `src/jg/coop/web/docs/handbook/practice.md`
- `src/jg/coop/web/docs/handbook/english.md`
- `src/jg/coop/web/docs/handbook/learn.md`

No other occurrences of the old URL exist in the project.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016y8MwPjXFEnLj1GKw57afr

---
_Generated by [Claude Code](https://claude.ai/code/session_016y8MwPjXFEnLj1GKw57afr)_