### PR TITLE
docs: clarify that `discord` imports are Pycord, not discord.py

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,3 +4,4 @@
 - Always run the `jg` project CLI as `uv run jg`. Always prefer `uv` over custom Python binary and virtual environment management.
 - Treat `jg sync` as a danger area. Never execute it deliberately unless the user explicitly instructed or approved that exact sync operation.
 - After significant changes to the Discord integration always check the [bot docs](src/jg/coop/web/docs/about/bot.md) if they need update.
+- The package imported as `discord` is [Pycord](https://docs.pycord.dev), not discord.py — the two differ, and Pycord is often installed bleeding-edge from git. Never rely on discord.py knowledge; always read the installed package source under `.venv/lib/**/site-packages/discord/` before drawing conclusions about its behavior.


### PR DESCRIPTION
## What

Adds one guidance line to `AGENTS.md` (symlinked as `CLAUDE.md`) stating that the package imported as `discord` is [Pycord](https://docs.pycord.dev), not discord.py.

## Why

The two libraries share the `discord` import name but differ in behavior, and this project installs Pycord bleeding-edge from git (`py-cord[speed]@git+https://github.com/Pycord-Development/pycord.git`). An agent trained heavily on discord.py can draw correct-sounding but wrong conclusions about runtime behavior (e.g. retry loops, iterator/pagination internals) by relying on discord.py facts. The new note requires reading the installed package source under `.venv/lib/**/site-packages/discord/` before drawing such conclusions.

## Change

- `AGENTS.md`: one bullet under "Guidance for AI agents".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U1zHpa3jcUdBDoccAS2dnH

---
_Generated by [Claude Code](https://claude.ai/code/session_01U1zHpa3jcUdBDoccAS2dnH)_