### PR TITLE
feat(club-content): retry Discord read timeouts

### DIFF
--- a/.claude/skills/code/SKILL.md
+++ b/.claude/skills/code/SKILL.md
@@ -18,6 +18,7 @@ description: Implement or modify Python, JavaScript, SCSS, templates, CLI, HTTP,
 - In `key=` callbacks such as `sorted()`, `max()`, and `min()`, prefer `attrgetter` or `itemgetter` over lambda when applicable.
 - Do not use `if TYPE_CHECKING:` blocks. Prefer direct imports and annotations.
 - Do not place imports inside functions or methods. Keep them at module level.
+- When a simple function opens with a long-ish explanatory comment, prefer a native Python docstring over a leading `#` comment block.
 - In SCSS, prefer `$spacer` over equivalent `map.get($spacers, 3)`.
 
 ## Tests

--- a/src/jg/coop/lib/discord_club.py
+++ b/src/jg/coop/lib/discord_club.py
@@ -1,5 +1,6 @@
 import asyncio
 import itertools
+import logging
 import re
 from collections.abc import AsyncGenerator
 from datetime import UTC, date, datetime, timedelta
@@ -10,6 +11,13 @@ from typing import TYPE_CHECKING, TypedDict
 
 import discord
 import emoji
+from tenacity import (
+    before_sleep_log,
+    retry,
+    retry_if_exception_type,
+    stop_after_attempt,
+    wait_random_exponential,
+)
 
 from jg.coop.lib import loggers, mutations
 
@@ -136,21 +144,41 @@ class ClubEmoji(StrEnum):
     SPONSOR_INTRO = "👋"
 
 
+def _is_read(route) -> bool:
+    return route.method in ("GET", "HEAD", "OPTIONS")
+
+
+@retry(
+    retry=retry_if_exception_type(TimeoutError),
+    wait=wait_random_exponential(max=60),
+    stop=stop_after_attempt(5),
+    reraise=True,
+    before_sleep=before_sleep_log(logger, logging.WARNING),
+)
+async def _request_with_retry(request, route, *args, **kwargs):
+    # Pycord's own request loop retries 429, 5xx, and connection resets, but
+    # lets read timeouts propagate on the first try, so retry them here. Scoped
+    # to reads (see _check_mutations) as retrying a mutation could apply it twice.
+    return await request(route, *args, **kwargs)
+
+
 def _check_mutations(request):
     def is_dm_channel_creation(route) -> bool:
         return route.method == "POST" and route.path == "/users/@me/channels"
 
     @wraps(request)
     async def wrapper(route, *args, **kwargs):
-        if (
+        if not (
             mutations.is_allowed("discord")
-            or route.method in ("GET", "HEAD", "OPTIONS")
+            or _is_read(route)
             or is_dm_channel_creation(route)
         ):
-            return await request(route, *args, **kwargs)
-        raise mutations.MutationsNotAllowedError(
-            f"Discord mutations not allowed! {route.method} {route.path}"
-        )
+            raise mutations.MutationsNotAllowedError(
+                f"Discord mutations not allowed! {route.method} {route.path}"
+            )
+        if _is_read(route):
+            return await _request_with_retry(request, route, *args, **kwargs)
+        return await request(route, *args, **kwargs)
 
     return wrapper
 

--- a/src/jg/coop/lib/discord_club.py
+++ b/src/jg/coop/lib/discord_club.py
@@ -156,29 +156,28 @@ def _is_read(route) -> bool:
     before_sleep=before_sleep_log(logger, logging.WARNING),
 )
 async def _request_with_retry(request, route, *args, **kwargs):
-    # Pycord's own request loop retries 429, 5xx, and connection resets, but
-    # lets read timeouts propagate on the first try, so retry them here. Scoped
-    # to reads (see _check_mutations) as retrying a mutation could apply it twice.
+    """Perform a Discord read request, retrying on read timeouts.
+
+    Pycord's own request loop retries 429, 5xx, and connection resets, but lets
+    read timeouts propagate on the first try, so retry them here. Scoped to
+    reads (see _intercept_request) as retrying a mutation could apply it twice.
+    """
     return await request(route, *args, **kwargs)
 
 
-def _check_mutations(request):
+def _intercept_request(request):
     def is_dm_channel_creation(route) -> bool:
         return route.method == "POST" and route.path == "/users/@me/channels"
 
     @wraps(request)
     async def wrapper(route, *args, **kwargs):
-        if not (
-            mutations.is_allowed("discord")
-            or _is_read(route)
-            or is_dm_channel_creation(route)
-        ):
-            raise mutations.MutationsNotAllowedError(
-                f"Discord mutations not allowed! {route.method} {route.path}"
-            )
         if _is_read(route):
             return await _request_with_retry(request, route, *args, **kwargs)
-        return await request(route, *args, **kwargs)
+        if mutations.is_allowed("discord") or is_dm_channel_creation(route):
+            return await request(route, *args, **kwargs)
+        raise mutations.MutationsNotAllowedError(
+            f"Discord mutations not allowed! {route.method} {route.path}"
+        )
 
     return wrapper
 
@@ -188,7 +187,7 @@ class ClubClient(discord.Client):
         club_intents = discord.Intents(guilds=True, members=True, message_content=True)
         kwargs["intents"] = kwargs.pop("intents", club_intents)
         super().__init__(*args, **kwargs)
-        self.http.request = _check_mutations(self.http.request)
+        self.http.request = _intercept_request(self.http.request)
 
     @property
     def club_guild(self) -> discord.Guild:

--- a/tests/test_lib_discord_club.py
+++ b/tests/test_lib_discord_club.py
@@ -3,6 +3,7 @@ from datetime import UTC, date, datetime, timedelta
 
 import pytest
 from discord import ChannelType, Route
+from tenacity import wait_none
 
 from jg.coop.lib import discord_club
 from jg.coop.lib.mutations import (
@@ -309,6 +310,57 @@ async def test_check_mutations_allows_dm_channel_creation(nothing_allowed):
         (route, 1, 2),
         {"kwarg1": 3, "kwarg2": 4},
     )
+
+
+@pytest.mark.asyncio
+async def test_check_mutations_retries_read_timeouts(nothing_allowed, monkeypatch):
+    monkeypatch.setattr(discord_club._request_with_retry.retry, "wait", wait_none())
+    calls = 0
+
+    @discord_club._check_mutations
+    async def request(*args, **kwargs):
+        nonlocal calls
+        calls += 1
+        if calls < 3:
+            raise TimeoutError()
+        return "ok"
+
+    assert await request(Route("GET", "/something")) == "ok"
+    assert calls == 3
+
+
+@pytest.mark.asyncio
+async def test_check_mutations_reraises_read_timeout_after_retries(
+    nothing_allowed, monkeypatch
+):
+    monkeypatch.setattr(discord_club._request_with_retry.retry, "wait", wait_none())
+    calls = 0
+
+    @discord_club._check_mutations
+    async def request(*args, **kwargs):
+        nonlocal calls
+        calls += 1
+        raise TimeoutError()
+
+    with pytest.raises(TimeoutError):
+        await request(Route("GET", "/something"))
+    assert calls == 5
+
+
+@pytest.mark.asyncio
+async def test_check_mutations_does_not_retry_mutation_timeouts(nothing_allowed):
+    allow("discord")
+    calls = 0
+
+    @discord_club._check_mutations
+    async def request(*args, **kwargs):
+        nonlocal calls
+        calls += 1
+        raise TimeoutError()
+
+    with pytest.raises(TimeoutError):
+        await request(Route("POST", "/something"))
+    assert calls == 1
 
 
 def test_get_missing_reactions():

--- a/tests/test_lib_discord_club.py
+++ b/tests/test_lib_discord_club.py
@@ -239,8 +239,8 @@ def test_parse_discord_link(url, expected):
     ],
 )
 @pytest.mark.asyncio
-async def test_check_mutations(nothing_allowed, method):
-    @discord_club._check_mutations
+async def test_intercept_request(nothing_allowed, method):
+    @discord_club._intercept_request
     async def request(*args, **kwargs):
         return args, kwargs
 
@@ -262,8 +262,8 @@ async def test_check_mutations(nothing_allowed, method):
     ],
 )
 @pytest.mark.asyncio
-async def test_check_mutations_raises(nothing_allowed, method):
-    @discord_club._check_mutations
+async def test_intercept_request_raises(nothing_allowed, method):
+    @discord_club._intercept_request
     async def request(*args, **kwargs):
         return args, kwargs
 
@@ -283,10 +283,12 @@ async def test_check_mutations_raises(nothing_allowed, method):
     ],
 )
 @pytest.mark.asyncio
-async def test_check_mutations_doesnt_raise_if_discord_allowed(nothing_allowed, method):
+async def test_intercept_request_doesnt_raise_if_discord_allowed(
+    nothing_allowed, method
+):
     allow("discord")
 
-    @discord_club._check_mutations
+    @discord_club._intercept_request
     async def request(*args, **kwargs):
         return args, kwargs
 
@@ -299,8 +301,8 @@ async def test_check_mutations_doesnt_raise_if_discord_allowed(nothing_allowed, 
 
 
 @pytest.mark.asyncio
-async def test_check_mutations_allows_dm_channel_creation(nothing_allowed):
-    @discord_club._check_mutations
+async def test_intercept_request_allows_dm_channel_creation(nothing_allowed):
+    @discord_club._intercept_request
     async def request(*args, **kwargs):
         return args, kwargs
 
@@ -313,11 +315,11 @@ async def test_check_mutations_allows_dm_channel_creation(nothing_allowed):
 
 
 @pytest.mark.asyncio
-async def test_check_mutations_retries_read_timeouts(nothing_allowed, monkeypatch):
+async def test_intercept_request_retries_read_timeouts(nothing_allowed, monkeypatch):
     monkeypatch.setattr(discord_club._request_with_retry.retry, "wait", wait_none())
     calls = 0
 
-    @discord_club._check_mutations
+    @discord_club._intercept_request
     async def request(*args, **kwargs):
         nonlocal calls
         calls += 1
@@ -330,13 +332,13 @@ async def test_check_mutations_retries_read_timeouts(nothing_allowed, monkeypatc
 
 
 @pytest.mark.asyncio
-async def test_check_mutations_reraises_read_timeout_after_retries(
+async def test_intercept_request_reraises_read_timeout_after_retries(
     nothing_allowed, monkeypatch
 ):
     monkeypatch.setattr(discord_club._request_with_retry.retry, "wait", wait_none())
     calls = 0
 
-    @discord_club._check_mutations
+    @discord_club._intercept_request
     async def request(*args, **kwargs):
         nonlocal calls
         calls += 1
@@ -348,11 +350,11 @@ async def test_check_mutations_reraises_read_timeout_after_retries(
 
 
 @pytest.mark.asyncio
-async def test_check_mutations_does_not_retry_mutation_timeouts(nothing_allowed):
+async def test_intercept_request_does_not_retry_mutation_timeouts(nothing_allowed):
     allow("discord")
     calls = 0
 
-    @discord_club._check_mutations
+    @discord_club._intercept_request
     async def request(*args, **kwargs):
         nonlocal calls
         calls += 1


### PR DESCRIPTION
## What

Wraps the Discord HTTP request (`_check_mutations` in `discord_club.py`) with a tenacity retry on `TimeoutError`, scoped to idempotent reads (`GET`/`HEAD`/`OPTIONS`): `wait_random_exponential(max=60)`, `stop_after_attempt(5)`, `reraise=True`, logging each retry at `WARNING`.

## Why

A recent nightly `sync-1` aborted mid-crawl with an `asyncio.TimeoutError` on a Discord message-history request. Reading the installed **Pycord** source (`discord/http.py`) confirms its own request loop retries only `429`, `5xx`, and connection-reset `OSError`s (errno 54/10054) — a read timeout has no matching errno and propagates on the first try, so nothing retries it today. This fills that gap.

## Why it can't corrupt data

The retry sits at the request level, below Pycord's history-pagination cursor. In `HistoryIterator._retrieve_messages_before_strategy`, the `before` cursor and `limit` are advanced **only after** the `logs_from` await returns (and messages are enqueued only after the full page is fetched). So a timed-out page is re-fetched with the identical cursor — no message is skipped or re-yielded, and no downstream store runs twice.

Mutations are never retried on timeout (they stay on the direct path) to avoid applying a non-idempotent write twice.

## Concurrency

`_request_with_retry` is shared across the 6 concurrent crawler workers. tenacity's `AsyncRetrying.__call__` builds a fresh local `RetryCallState` per invocation, so concurrent calls don't share retry-decision state (only the cosmetic `statistics` dict).

## Verification

- 3 new tests in `test_lib_discord_club.py`: a read timing out twice then succeeding is retried; a read that always times out reraises after 5 attempts; a mutation timeout is **not** retried (single call). Waits stubbed via `wait_none()` so tests stay fast.
- `tests/test_lib_discord_club.py`, `test_sync_club_content_crawler.py`, `test_models_club.py` all pass (132); `ruff check` and `ruff format --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U1zHpa3jcUdBDoccAS2dnH

---
_Generated by [Claude Code](https://claude.ai/code/session_01U1zHpa3jcUdBDoccAS2dnH)_